### PR TITLE
InlineHook: Increase hook removal safety

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,3 +23,4 @@ jobs:
           ./build-${{matrix.arch}}-${{matrix.build_type}}/${{matrix.build_type}}/test1.exe
           ./build-${{matrix.arch}}-${{matrix.build_type}}/${{matrix.build_type}}/test2.exe
           ./build-${{matrix.arch}}-${{matrix.build_type}}/${{matrix.build_type}}/test3.exe
+          ./build-${{matrix.arch}}-${{matrix.build_type}}/${{matrix.build_type}}/test4.exe

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -269,3 +269,38 @@ if(SAFETYHOOK_BUILD_TESTS) # build-tests
 	unset(CMKR_SOURCES)
 endif()
 
+# Target test4
+if(SAFETYHOOK_BUILD_TESTS) # build-tests
+	set(CMKR_TARGET test4)
+	set(test4_SOURCES "")
+
+	list(APPEND test4_SOURCES
+		"tests/test4.cpp"
+	)
+
+	list(APPEND test4_SOURCES
+		cmake.toml
+	)
+
+	set(CMKR_SOURCES ${test4_SOURCES})
+	add_executable(test4)
+
+	if(test4_SOURCES)
+		target_sources(test4 PRIVATE ${test4_SOURCES})
+	endif()
+
+	get_directory_property(CMKR_VS_STARTUP_PROJECT DIRECTORY ${PROJECT_SOURCE_DIR} DEFINITION VS_STARTUP_PROJECT)
+	if(NOT CMKR_VS_STARTUP_PROJECT)
+		set_property(DIRECTORY ${PROJECT_SOURCE_DIR} PROPERTY VS_STARTUP_PROJECT test4)
+	endif()
+
+	source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} FILES ${test4_SOURCES})
+
+	target_link_libraries(test4 PRIVATE
+		safetyhook::safetyhook
+	)
+
+	unset(CMKR_TARGET)
+	unset(CMKR_SOURCES)
+endif()
+

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ int add(int x, int y) {
 SafetyHookInline g_add_hook{};
 
 int hook_add(int x, int y) {
-    return g_add_hook->call<int>(x * 2, y * 2);
+    return g_add_hook.call<int>(x * 2, y * 2);
 }
 
 int main(int argc, char* argv[]) {
@@ -70,7 +70,7 @@ int main(int argc, char* argv[]) {
 
     std::cout << "hooked add(2, 3) = " << add(2, 3) << "\n";
 
-    g_add_hook.reset();
+    g_add_hook = {};
 
     std::cout << "unhooked add(2, 3) = " << add(2, 3) << "\n";
 

--- a/cmake.toml
+++ b/cmake.toml
@@ -50,3 +50,9 @@ condition = "build-tests"
 type = "executable"
 sources = ["tests/test3.cpp"]
 link-libraries = ["safetyhook::safetyhook"]
+
+[target.test4]
+condition = "build-tests"
+type = "executable"
+sources = ["tests/test4.cpp"]
+link-libraries = ["safetyhook::safetyhook"]

--- a/include/SafetyHook.hpp
+++ b/include/SafetyHook.hpp
@@ -10,7 +10,7 @@
 using SafetyHookBuilder = safetyhook::Builder;
 using SafetyHookFactory = safetyhook::Factory;
 using SafetyHookContext = safetyhook::Context;
-using SafetyHookInline = std::unique_ptr<safetyhook::InlineHook>;
-using SafetyHookMid = std::unique_ptr<safetyhook::MidHook>;
-using SafetyInlineHook [[deprecated("Use SafetyHookInline instead.")]] = std::unique_ptr<safetyhook::InlineHook>;
-using SafetyMidHook [[deprecated("Use SafetyHookMid instead.")]] = std::unique_ptr<safetyhook::MidHook>;
+using SafetyHookInline = safetyhook::InlineHook;
+using SafetyHookMid = safetyhook::MidHook;
+using SafetyInlineHook [[deprecated("Use SafetyHookInline instead.")]] = safetyhook::InlineHook;
+using SafetyMidHook [[deprecated("Use SafetyHookMid instead.")]] = safetyhook::MidHook;

--- a/include/safetyhook/Builder.hpp
+++ b/include/safetyhook/Builder.hpp
@@ -21,8 +21,8 @@ public:
 
     ~Builder();
 
-    [[nodiscard]] std::unique_ptr<InlineHook> create_inline(void* target, void* destination);
-    [[nodiscard]] std::unique_ptr<MidHook> create_mid(void* target, MidHookFn destination);
+    [[nodiscard]] InlineHook create_inline(void* target, void* destination);
+    [[nodiscard]] MidHook create_mid(void* target, MidHookFn destination);
 
 private:
     friend Factory;

--- a/include/safetyhook/Factory.hpp
+++ b/include/safetyhook/Factory.hpp
@@ -37,7 +37,7 @@ private:
     };
 
     std::vector<std::unique_ptr<MemoryAllocation>> m_allocations{};
-    std::mutex m_mux{};
+    std::mutex m_mutex{};
     Builder* m_builder{};
 
     Factory();

--- a/include/safetyhook/InlineHook.hpp
+++ b/include/safetyhook/InlineHook.hpp
@@ -30,36 +30,30 @@ public:
     template <typename T> [[nodiscard]] T* original() const { return (T*)m_trampoline; }
 
     template <typename RetT = void, typename... Args> auto call(Args&&... args) {
-        m_mutex.lock();
-        auto trampoline = m_trampoline;
-        m_mutex.unlock();
+        std::scoped_lock lock{m_mutex};
 
-        if (trampoline != 0) {
-            return ((RetT(*)(Args...))trampoline)(std::forward<Args>(args)...);
+        if (m_trampoline != 0) {
+            return unsafe_call<RetT, Args...>(std::forward<Args>(args)...);
         } else {
             return RetT();
         }
     }
 
     template <typename RetT = void, typename... Args> auto thiscall(Args&&... args) {
-        m_mutex.lock();
-        auto trampoline = m_trampoline;
-        m_mutex.unlock();
+        std::scoped_lock lock{m_mutex};
 
-        if (trampoline != 0) {
-            return ((RetT(__thiscall*)(Args...))trampoline)(std::forward<Args>(args)...);
+        if (m_trampoline != 0) {
+            return unsafe_thiscall<RetT, Args...>(std::forward<Args>(args)...);
         } else {
             return RetT();
         }
     }
 
     template <typename RetT = void, typename... Args> auto stdcall(Args&&... args) {
-        m_mutex.lock();
-        auto trampoline = m_trampoline;
-        m_mutex.unlock();
+        std::scoped_lock lock{m_mutex};
 
-        if (trampoline != 0) {
-            return ((RetT(__stdcall*)(Args...))trampoline)(std::forward<Args>(args)...);
+        if (m_trampoline != 0) {
+            return unsafe_stdcall<RetT, Args...>(std::forward<Args>(args)...);
         } else {
             return RetT();
         }

--- a/include/safetyhook/InlineHook.hpp
+++ b/include/safetyhook/InlineHook.hpp
@@ -2,6 +2,7 @@
 
 #include <cstdint>
 #include <memory>
+#include <mutex>
 #include <vector>
 
 namespace safetyhook {
@@ -26,6 +27,8 @@ public:
     template <typename T> [[nodiscard]] T* original() const { return (T*)m_trampoline; }
 
     template <typename RetT = void, typename... Args> auto call(Args... args) {
+        std::scoped_lock lock{m_mutex};
+
         if (m_trampoline != 0) {
             return ((RetT(*)(Args...))m_trampoline)(args...);
         } else {
@@ -34,6 +37,8 @@ public:
     }
 
     template <typename RetT = void, typename... Args> auto thiscall(Args... args) {
+        std::scoped_lock lock{m_mutex};
+
         if (m_trampoline != 0) {
             return ((RetT(__thiscall*)(Args...))m_trampoline)(args...);
         } else {
@@ -42,6 +47,8 @@ public:
     }
 
     template <typename RetT = void, typename... Args> auto stdcall(Args... args) {
+        std::scoped_lock lock{m_mutex};
+
         if (m_trampoline != 0) {
             return ((RetT(__stdcall*)(Args...))m_trampoline)(args...);
         } else {
@@ -59,6 +66,7 @@ private:
     size_t m_trampoline_size{};
     size_t m_trampoline_allocation_size{};
     std::vector<uint8_t> m_original_bytes{};
+    std::mutex m_mutex{};
 
     InlineHook(std::shared_ptr<Factory> factory, uintptr_t target, uintptr_t destination);
 

--- a/include/safetyhook/InlineHook.hpp
+++ b/include/safetyhook/InlineHook.hpp
@@ -29,31 +29,31 @@ public:
 
     template <typename T> [[nodiscard]] T* original() const { return (T*)m_trampoline; }
 
-    template <typename RetT = void, typename... Args> auto call(Args&&... args) {
+    template <typename RetT = void, typename... Args> auto call(Args... args) {
         std::scoped_lock lock{m_mutex};
 
         if (m_trampoline != 0) {
-            return unsafe_call<RetT, Args...>(std::forward<Args>(args)...);
+            return ((RetT(*)(Args...))m_trampoline)(args...);
         } else {
             return RetT();
         }
     }
 
-    template <typename RetT = void, typename... Args> auto thiscall(Args&&... args) {
+    template <typename RetT = void, typename... Args> auto thiscall(Args... args) {
         std::scoped_lock lock{m_mutex};
 
         if (m_trampoline != 0) {
-            return unsafe_thiscall<RetT, Args...>(std::forward<Args>(args)...);
+            return ((RetT(__thiscall*)(Args...))m_trampoline)(args...);
         } else {
             return RetT();
         }
     }
 
-    template <typename RetT = void, typename... Args> auto stdcall(Args&&... args) {
+    template <typename RetT = void, typename... Args> auto stdcall(Args... args) {
         std::scoped_lock lock{m_mutex};
 
         if (m_trampoline != 0) {
-            return unsafe_stdcall<RetT, Args...>(std::forward<Args>(args)...);
+            return ((RetT(__stdcall*)(Args...))m_trampoline)(args...);
         } else {
             return RetT();
         }
@@ -61,16 +61,16 @@ public:
 
     // These functions are unsafe because they don't lock the mutex. Only use these if you don't care about unhook
     // safety or are worried about the performance cost of locking the mutex.
-    template <typename RetT = void, typename... Args> auto unsafe_call(Args&&... args) {
-        return ((RetT(*)(Args...))m_trampoline)(std::forward<Args>(args)...);
+    template <typename RetT = void, typename... Args> auto unsafe_call(Args... args) {
+        return ((RetT(*)(Args...))m_trampoline)(args...);
     }
 
-    template <typename RetT = void, typename... Args> auto unsafe_thiscall(Args&&... args) {
-        return ((RetT(__thiscall*)(Args...))m_trampoline)(std::forward<Args>(args)...);
+    template <typename RetT = void, typename... Args> auto unsafe_thiscall(Args... args) {
+        return ((RetT(__thiscall*)(Args...))m_trampoline)(args...);
     }
 
-    template <typename RetT = void, typename... Args> auto unsafe_stdcall(Args&&... args) {
-        return ((RetT(__stdcall*)(Args...))m_trampoline)(std::forward<Args>(args)...);
+    template <typename RetT = void, typename... Args> auto unsafe_stdcall(Args... args) {
+        return ((RetT(__stdcall*)(Args...))m_trampoline)(args...);
     }
 
 private:

--- a/include/safetyhook/InlineHook.hpp
+++ b/include/safetyhook/InlineHook.hpp
@@ -10,30 +10,43 @@ class Builder;
 
 class InlineHook final {
 public:
-    InlineHook() = delete;
+    InlineHook() = default;
     InlineHook(const InlineHook&) = delete;
-    InlineHook(InlineHook&&) noexcept = delete;
+    InlineHook(InlineHook&& other) noexcept;
     InlineHook& operator=(const InlineHook&) = delete;
-    InlineHook& operator=(InlineHook&&) noexcept = delete;
+    InlineHook& operator=(InlineHook&& other) noexcept;
 
     ~InlineHook();
 
     [[nodiscard]] auto target() const { return m_target; }
     [[nodiscard]] auto destination() const { return m_destination; }
     [[nodiscard]] auto trampoline() const { return m_trampoline; }
+    operator bool() const { return m_trampoline != 0; }
 
     template <typename T> [[nodiscard]] T* original() const { return (T*)m_trampoline; }
 
     template <typename RetT = void, typename... Args> auto call(Args... args) {
-        return ((RetT(*)(Args...))m_trampoline)(args...);
+        if (m_trampoline != 0) {
+            return ((RetT(*)(Args...))m_trampoline)(args...);
+        } else {
+            return RetT{};
+        }
     }
 
     template <typename RetT = void, typename... Args> auto thiscall(Args... args) {
-        return ((RetT(__thiscall*)(Args...))m_trampoline)(args...);
+        if (m_trampoline != 0) {
+            return ((RetT(__thiscall*)(Args...))m_trampoline)(args...);
+        } else {
+            return RetT{};
+        }
     }
 
     template <typename RetT = void, typename... Args> auto stdcall(Args... args) {
-        return ((RetT(__stdcall*)(Args...))m_trampoline)(args...);
+        if (m_trampoline != 0) {
+            return ((RetT(__stdcall*)(Args...))m_trampoline)(args...);
+        } else {
+            return RetT{};
+        }
     }
 
 private:
@@ -51,5 +64,6 @@ private:
 
     void e9_hook();
     void ff_hook();
+    void destroy();
 };
 } // namespace safetyhook

--- a/include/safetyhook/InlineHook.hpp
+++ b/include/safetyhook/InlineHook.hpp
@@ -20,7 +20,7 @@ public:
 
     ~InlineHook();
 
-    void unhook();
+    void reset();
 
     [[nodiscard]] auto target() const { return m_target; }
     [[nodiscard]] auto destination() const { return m_destination; }

--- a/include/safetyhook/InlineHook.hpp
+++ b/include/safetyhook/InlineHook.hpp
@@ -20,6 +20,8 @@ public:
 
     ~InlineHook();
 
+    void unhook();
+
     [[nodiscard]] auto target() const { return m_target; }
     [[nodiscard]] auto destination() const { return m_destination; }
     [[nodiscard]] auto trampoline() const { return m_trampoline; }

--- a/include/safetyhook/MidHook.hpp
+++ b/include/safetyhook/MidHook.hpp
@@ -20,6 +20,8 @@ public:
 
     ~MidHook();
 
+    void unhook();
+
     [[nodiscard]] auto target() const { return m_target; }
     [[nodiscard]] auto destination() const { return m_destination; }
     operator bool() const { return m_stub != 0; }

--- a/include/safetyhook/MidHook.hpp
+++ b/include/safetyhook/MidHook.hpp
@@ -4,30 +4,31 @@
 #include <memory>
 
 #include "safetyhook/Context.hpp"
+#include "safetyhook/InlineHook.hpp"
 
 namespace safetyhook {
 class Factory;
 class Builder;
-class InlineHook;
 
 class MidHook final {
 public:
-    MidHook() = delete;
+    MidHook() = default;
     MidHook(const MidHook&) = delete;
-    MidHook(MidHook&&) noexcept = delete;
+    MidHook(MidHook&& other) noexcept;
     MidHook& operator=(const MidHook&) = delete;
-    MidHook& operator=(MidHook&&) noexcept = delete;
+    MidHook& operator=(MidHook&& other) noexcept;
 
     ~MidHook();
 
     [[nodiscard]] auto target() const { return m_target; }
     [[nodiscard]] auto destination() const { return m_destination; }
+    operator bool() const { return m_stub != 0; }
 
 private:
     friend Builder;
 
     std::shared_ptr<Factory> m_factory{};
-    std::unique_ptr<InlineHook> m_hook{};
+    InlineHook m_hook{};
     uintptr_t m_target{};
     uintptr_t m_stub{};
     MidHookFn m_destination{};

--- a/include/safetyhook/MidHook.hpp
+++ b/include/safetyhook/MidHook.hpp
@@ -20,7 +20,7 @@ public:
 
     ~MidHook();
 
-    void unhook();
+    void reset();
 
     [[nodiscard]] auto target() const { return m_target; }
     [[nodiscard]] auto destination() const { return m_destination; }

--- a/src/Builder.cpp
+++ b/src/Builder.cpp
@@ -10,24 +10,12 @@ Builder::~Builder() {
     m_factory->m_builder = nullptr;
 }
 
-std::unique_ptr<InlineHook> Builder::create_inline(void* target, void* destination) {
-    auto hook = std::unique_ptr<InlineHook>{new InlineHook{m_factory, (uintptr_t)target, (uintptr_t)destination}};
-
-    if (hook->m_trampoline == 0) {
-        return nullptr;
-    }
-
-    return hook;
+InlineHook Builder::create_inline(void* target, void* destination) {
+    return InlineHook{m_factory, (uintptr_t)target, (uintptr_t)destination};
 }
 
-std::unique_ptr<MidHook> Builder::create_mid(void* target, MidHookFn destination) {
-    auto hook = std::unique_ptr<MidHook>{new MidHook{m_factory, (uintptr_t)target, destination}};
-
-    if (hook->m_stub == 0) {
-        return nullptr;
-    }
-
-    return hook;
+MidHook Builder::create_mid(void* target, MidHookFn destination) {
+    return MidHook{m_factory, (uintptr_t)target, destination};
 }
 
 Builder::Builder(std::shared_ptr<Factory> factory) : m_factory{std::move(factory)} {

--- a/src/Builder.cpp
+++ b/src/Builder.cpp
@@ -19,7 +19,7 @@ MidHook Builder::create_mid(void* target, MidHookFn destination) {
 }
 
 Builder::Builder(std::shared_ptr<Factory> factory) : m_factory{std::move(factory)} {
-    std::scoped_lock _{m_factory->m_mux};
+    std::scoped_lock lock{m_factory->m_mutex};
 
     if (m_factory->m_builder == nullptr) {
         m_factory->m_builder = this;
@@ -34,17 +34,17 @@ void Builder::fix_ip(uintptr_t old_ip, uintptr_t new_ip) {
 }
 
 uintptr_t Builder::allocate(size_t size) {
-    std::scoped_lock _{m_factory->m_mux};
+    std::scoped_lock lock{m_factory->m_mutex};
     return m_factory->allocate(size);
 }
 
 uintptr_t Builder::allocate_near(const std::vector<uintptr_t>& desired_addresses, size_t size, size_t max_distance) {
-    std::scoped_lock _{m_factory->m_mux};
+    std::scoped_lock lock{m_factory->m_mutex};
     return m_factory->allocate_near(desired_addresses, size, max_distance);
 }
 
 void Builder::free(uintptr_t address, size_t size) {
-    std::scoped_lock _{m_factory->m_mux};
+    std::scoped_lock lock{m_factory->m_mutex};
     m_factory->free(address, size);
 }
 } // namespace safetyhook

--- a/src/Factory.cpp
+++ b/src/Factory.cpp
@@ -11,7 +11,7 @@
 
 namespace safetyhook {
 Factory* g_factory{};
-std::mutex g_factory_mux{};
+std::mutex g_factory_mutex{};
 
 constexpr auto align_up(uintptr_t address, size_t align) {
     return (address + align - 1) & ~(align - 1);
@@ -22,7 +22,7 @@ constexpr auto align_down(uintptr_t address, size_t align) {
 }
 
 Builder Factory::acquire() {
-    std::scoped_lock _{g_factory_mux};
+    std::scoped_lock lock{g_factory_mutex};
 
     if (g_factory == nullptr) {
         return Builder{std::shared_ptr<Factory>{new Factory}};

--- a/src/InlineHook.cpp
+++ b/src/InlineHook.cpp
@@ -298,5 +298,7 @@ void InlineHook::destroy() {
     // If the IP is on the trampolines jmp.
     builder.fix_ip(m_trampoline + m_trampoline_size, m_target + m_trampoline_size);
     builder.free(m_trampoline, m_trampoline_allocation_size);
+
+    m_trampoline = 0;
 }
 } // namespace safetyhook

--- a/src/InlineHook.cpp
+++ b/src/InlineHook.cpp
@@ -122,6 +122,10 @@ InlineHook::~InlineHook() {
     destroy();
 }
 
+void InlineHook::unhook() {
+    *this = {};
+}
+
 InlineHook::InlineHook(std::shared_ptr<Factory> factory, uintptr_t target, uintptr_t destination)
     : m_factory{std::move(factory)}, m_target{target}, m_destination{destination} {
     e9_hook();

--- a/src/InlineHook.cpp
+++ b/src/InlineHook.cpp
@@ -103,8 +103,7 @@ InlineHook::InlineHook(InlineHook&& other) noexcept {
 InlineHook& InlineHook::operator=(InlineHook&& other) noexcept {
     destroy();
 
-    std::scoped_lock my_lock{m_mutex};
-    std::scoped_lock other_lock{other.m_mutex};
+    std::scoped_lock lock{m_mutex, other.m_mutex};
 
     m_factory = std::move(other.m_factory);
     m_target = other.m_target;

--- a/src/InlineHook.cpp
+++ b/src/InlineHook.cpp
@@ -122,7 +122,7 @@ InlineHook::~InlineHook() {
     destroy();
 }
 
-void InlineHook::unhook() {
+void InlineHook::reset() {
     *this = {};
 }
 

--- a/src/MidHook.cpp
+++ b/src/MidHook.cpp
@@ -40,6 +40,17 @@ MidHook& MidHook::operator=(MidHook&& other) noexcept {
     return *this;
 }
 
+MidHook::~MidHook() {
+    if (m_stub != 0) {
+        auto builder = Factory::acquire();
+        builder.free(m_stub, sizeof(asm_data));
+    }
+}
+
+void MidHook::unhook() {
+    *this = {};
+}
+
 MidHook::MidHook(std::shared_ptr<Factory> factory, uintptr_t target, MidHookFn destination)
     : m_factory{std::move(factory)}, m_target{target}, m_destination{destination} {
     auto builder = Factory::acquire();
@@ -71,12 +82,4 @@ MidHook::MidHook(std::shared_ptr<Factory> factory, uintptr_t target, MidHookFn d
     *(uintptr_t*)(m_stub + sizeof(asm_data) - 4) = m_hook.trampoline();
 #endif
 }
-
-MidHook::~MidHook() {
-    if (m_stub != 0) {
-        auto builder = Factory::acquire();
-        builder.free(m_stub, sizeof(asm_data));
-    }
-}
-
 } // namespace safetyhook

--- a/src/MidHook.cpp
+++ b/src/MidHook.cpp
@@ -47,7 +47,7 @@ MidHook::~MidHook() {
     }
 }
 
-void MidHook::unhook() {
+void MidHook::reset() {
     *this = {};
 }
 

--- a/tests/test0.cpp
+++ b/tests/test0.cpp
@@ -9,19 +9,19 @@ __declspec(noinline) void say_hi(const std::string& name) {
 }
 
 void hook0_fn(const std::string& name) {
-    hook0->call<void, const std::string&>(name + " and bob");
+    hook0.call<void, const std::string&>(name + " and bob");
 }
 
 void hook1_fn(const std::string& name) {
-    hook1->call<void, const std::string&>(name + " and alice");
+    hook1.call<void, const std::string&>(name + " and alice");
 }
 
 void hook2_fn(const std::string& name) {
-    hook2->call<void, const std::string&>(name + " and eve");
+    hook2.call<void, const std::string&>(name + " and eve");
 }
 
 void hook3_fn(const std::string& name) {
-    hook3->call<void, const std::string&>(name + " and carol");
+    hook3.call<void, const std::string&>(name + " and carol");
 }
 
 int main() {

--- a/tests/test1.cpp
+++ b/tests/test1.cpp
@@ -9,7 +9,7 @@ __declspec(noinline) int add(int x, int y) {
 SafetyHookInline g_add_hook{};
 
 int hook_add(int x, int y) {
-    return g_add_hook->call<int>(x * 2, y * 2);
+    return g_add_hook.call<int>(x * 2, y * 2);
 }
 
 int main() {
@@ -29,7 +29,7 @@ int main() {
 
     std::cout << "hooked add(3, 4) = " << add(3, 4) << "\n";
 
-    g_add_hook.reset();
+    g_add_hook = {};
 
     std::cout << "unhooked add(5, 6) = " << add(5, 6) << "\n";
 

--- a/tests/test2.cpp
+++ b/tests/test2.cpp
@@ -42,7 +42,7 @@ int main() {
 
     std::cout << add_42(3) << "\n";
 
-    g_hook.unhook();
+    g_hook.reset();
 
     std::cout << add_42(4) << "\n";
 

--- a/tests/test2.cpp
+++ b/tests/test2.cpp
@@ -42,7 +42,7 @@ int main() {
 
     std::cout << add_42(3) << "\n";
 
-    g_hook.reset();
+    g_hook = {};
 
     std::cout << add_42(4) << "\n";
 

--- a/tests/test2.cpp
+++ b/tests/test2.cpp
@@ -42,7 +42,7 @@ int main() {
 
     std::cout << add_42(3) << "\n";
 
-    g_hook = {};
+    g_hook.unhook();
 
     std::cout << add_42(4) << "\n";
 

--- a/tests/test3.cpp
+++ b/tests/test3.cpp
@@ -10,19 +10,19 @@ __declspec(noinline) void say_hi(const std::string& name) {
 }
 
 void hook0_fn(const std::string& name) {
-    hook0->call<void, const std::string&>(name + " and bob");
+    hook0.call<void, const std::string&>(name + " and bob");
 }
 
 void hook1_fn(const std::string& name) {
-    hook1->call<void, const std::string&>(name + " and alice");
+    hook1.call<void, const std::string&>(name + " and alice");
 }
 
 void hook2_fn(const std::string& name) {
-    hook2->call<void, const std::string&>(name + " and eve");
+    hook2.call<void, const std::string&>(name + " and eve");
 }
 
 void hook3_fn(const std::string& name) {
-    hook3->call<void, const std::string&>(name + " and carol");
+    hook3.call<void, const std::string&>(name + " and carol");
 }
 
 int main() {

--- a/tests/test4.cpp
+++ b/tests/test4.cpp
@@ -1,0 +1,40 @@
+#include <iostream>
+
+#include <SafetyHook.hpp>
+
+SafetyHookInline g_hook{};
+
+__declspec(noinline) void SayHello(int times) {
+    std::cout << "Hello #" << times << std::endl;
+}
+
+void Hooked_SayHello(int times) {
+    g_hook.call<void, int>(1337);
+}
+
+void SayHelloInfinitely() {
+    int count = 0;
+
+    while (true) {
+        SayHello(count++);
+    }
+}
+
+int main() {
+    // Starting a thread for SayHello
+    std::thread t(SayHelloInfinitely);
+    t.detach();
+
+    {
+        auto builder = SafetyHookFactory::acquire();
+        g_hook = builder.create_inline(SayHello, Hooked_SayHello);
+    }
+
+    std::this_thread::sleep_for(std::chrono::seconds(1));
+
+    g_hook = {};
+
+    std::this_thread::sleep_for(std::chrono::seconds(1));
+
+    return 0;
+}

--- a/tests/test4.cpp
+++ b/tests/test4.cpp
@@ -32,7 +32,7 @@ int main() {
 
     std::this_thread::sleep_for(std::chrono::seconds(1));
 
-    g_hook.unhook();
+    g_hook.reset();
 
     std::this_thread::sleep_for(std::chrono::seconds(1));
 

--- a/tests/test4.cpp
+++ b/tests/test4.cpp
@@ -32,7 +32,7 @@ int main() {
 
     std::this_thread::sleep_for(std::chrono::seconds(1));
 
-    g_hook = {};
+    g_hook.unhook();
 
     std::this_thread::sleep_for(std::chrono::seconds(1));
 


### PR DESCRIPTION
This also changes InlineHook and MidHook's to be movable and default initialize-able. It changes builder to return InlineHook/MidHooks directly instead of wrapped in a std::unique_ptr.