### PR TITLE
InlineHook: Freeze threads only when installing inline hook

### DIFF
--- a/include/safetyhook/Builder.hpp
+++ b/include/safetyhook/Builder.hpp
@@ -10,7 +10,6 @@ namespace safetyhook {
 class InlineHook;
 class MidHook;
 class Factory;
-class ThreadFreezer;
 
 class Builder final {
 public:
@@ -18,8 +17,7 @@ public:
     Builder(Builder&&) noexcept = delete;
     Builder& operator=(const Builder&) = delete;
     Builder& operator=(Builder&&) noexcept = delete;
-
-    ~Builder();
+    ~Builder() = default;
 
     [[nodiscard]] InlineHook create_inline(void* target, void* destination);
     [[nodiscard]] MidHook create_mid(void* target, MidHookFn destination);
@@ -30,11 +28,9 @@ private:
     friend MidHook;
 
     std::shared_ptr<Factory> m_factory{};
-    std::shared_ptr<ThreadFreezer> m_threads{};
 
     explicit Builder(std::shared_ptr<Factory> f);
 
-    void fix_ip(uintptr_t old_ip, uintptr_t new_ip);
     [[nodiscard]] uintptr_t allocate(size_t size);
     [[nodiscard]] uintptr_t allocate_near(
         const std::vector<uintptr_t>& desired_addresses, size_t size, size_t max_distance = 0x7FFF'FFFF);

--- a/include/safetyhook/Factory.hpp
+++ b/include/safetyhook/Factory.hpp
@@ -38,7 +38,6 @@ private:
 
     std::vector<std::unique_ptr<MemoryAllocation>> m_allocations{};
     std::mutex m_mutex{};
-    Builder* m_builder{};
 
     Factory();
 

--- a/src/Builder.cpp
+++ b/src/Builder.cpp
@@ -1,17 +1,10 @@
 #include "safetyhook/Factory.hpp"
 #include "safetyhook/InlineHook.hpp"
 #include "safetyhook/MidHook.hpp"
-#include "safetyhook/ThreadFreezer.hpp"
 
 #include "safetyhook/Builder.hpp"
 
 namespace safetyhook {
-Builder::~Builder() {
-    if (m_factory->m_builder == this) {
-        m_factory->m_builder = nullptr;
-    }
-}
-
 InlineHook Builder::create_inline(void* target, void* destination) {
     return InlineHook{m_factory, (uintptr_t)target, (uintptr_t)destination};
 }
@@ -21,18 +14,6 @@ MidHook Builder::create_mid(void* target, MidHookFn destination) {
 }
 
 Builder::Builder(std::shared_ptr<Factory> factory) : m_factory{std::move(factory)} {
-    std::scoped_lock lock{m_factory->m_mutex};
-
-    if (m_factory->m_builder == nullptr) {
-        m_factory->m_builder = this;
-        m_threads = std::make_shared<ThreadFreezer>();
-    } else {
-        m_threads = m_factory->m_builder->m_threads;
-    }
-}
-
-void Builder::fix_ip(uintptr_t old_ip, uintptr_t new_ip) {
-    m_threads->fix_ip(old_ip, new_ip);
 }
 
 uintptr_t Builder::allocate(size_t size) {

--- a/src/ThreadFreezer.cpp
+++ b/src/ThreadFreezer.cpp
@@ -14,17 +14,6 @@ NtGetNextThread(HANDLE ProcessHandle, HANDLE ThreadHandle, ACCESS_MASK DesiredAc
 
 namespace safetyhook {
 ThreadFreezer::ThreadFreezer() {
-    auto peb = reinterpret_cast<uintptr_t>(NtCurrentTeb()->ProcessEnvironmentBlock);
-
-#if defined(_M_X64)
-    auto loader_lock = *reinterpret_cast<RTL_CRITICAL_SECTION**>(peb + 0x110);
-#elif defined(_M_IX86)
-    auto loader_lock = *reinterpret_cast<RTL_CRITICAL_SECTION**>(peb + 0xA0);
-#else
-#error "Unsupported architecture"
-#endif
-    EnterCriticalSection(loader_lock);
-
     size_t num_threads_frozen{};
 
     do {
@@ -62,8 +51,6 @@ ThreadFreezer::ThreadFreezer() {
             m_frozen_threads.push_back({thread_id, thread, thread_ctx});
         }
     } while (num_threads_frozen != m_frozen_threads.size());
-
-    LeaveCriticalSection(loader_lock);
 }
 
 ThreadFreezer::~ThreadFreezer() {


### PR DESCRIPTION
Closes #16.

Thanks to improvements to the `ThreadFreezer` it is now less problematic to just freeze the threads each time `InlineHook` is installing the branch to trampoline.

This has the added benefit of simplifying the `Builder` as well.