### PR TITLE
Refactor: Replace uintptr_t addresses with uint8_t*

### DIFF
--- a/format.ps1
+++ b/format.ps1
@@ -1,4 +1,4 @@
-Get-ChildItem -Path .\src, .\include, .\tests -Include *.hpp, *.cpp -Recurse | 
+Get-ChildItem -Path .\src, .\include, .\tests, .\unittest -Include *.hpp, *.cpp -Recurse |
 ForEach-Object {
     Write-Output $_.FullName
     &clang-format -i -style=file $_.FullName

--- a/include/safetyhook/allocator.hpp
+++ b/include/safetyhook/allocator.hpp
@@ -28,7 +28,7 @@ public:
 
     /// @brief Returns the address of the allocation.
     /// @return The address of the allocation.
-    [[nodiscard]] uintptr_t address() const noexcept { return m_address; }
+    [[nodiscard]] uint8_t* address() const noexcept { return m_address; }
 
     /// @brief Returns the size of the allocation.
     /// @return The size of the allocation.
@@ -36,16 +36,16 @@ public:
 
     /// @brief Tests if the allocation is valid.
     /// @return True if the allocation is valid, false otherwise.
-    explicit operator bool() const noexcept { return m_address != 0 && m_size != 0; }
+    explicit operator bool() const noexcept { return m_address != nullptr && m_size != 0; }
 
 protected:
     friend Allocator;
 
-    Allocation(std::shared_ptr<Allocator> allocator, uintptr_t address, size_t size) noexcept;
+    Allocation(std::shared_ptr<Allocator> allocator, uint8_t* address, size_t size) noexcept;
 
 private:
     std::shared_ptr<Allocator> m_allocator{};
-    uintptr_t m_address{};
+    uint8_t* m_address{};
     size_t m_size{};
 };
 
@@ -78,27 +78,27 @@ public:
     [[nodiscard]] std::expected<Allocation, Error> allocate(size_t size);
 
     /// @brief Allocates memory near a target address.
-    /// @param desired_address The target address.
+    /// @param desired_addresses The target address.
     /// @param size The size of the allocation.
     /// @param max_distance The maximum distance from the target address.
     /// @return The Allocation or an Allocator::Error if the allocation failed.
     [[nodiscard]] std::expected<Allocation, Error> allocate_near(
-        const std::vector<uintptr_t>& desired_addresses, size_t size, size_t max_distance = 0x7FFF'FFFF);
+        const std::vector<uint8_t*>& desired_addresses, size_t size, size_t max_distance = 0x7FFF'FFFF);
 
 protected:
     friend Allocation;
 
-    void free(uintptr_t address, size_t size);
+    void free(uint8_t* address, size_t size);
 
 private:
     struct FreeNode {
         std::unique_ptr<FreeNode> next{};
-        uintptr_t start{};
-        uintptr_t end{};
+        uint8_t* start{};
+        uint8_t* end{};
     };
 
     struct Memory {
-        uintptr_t address{};
+        uint8_t* address{};
         size_t size{};
         std::unique_ptr<FreeNode> freelist{};
 
@@ -111,13 +111,13 @@ private:
     Allocator() = default;
 
     [[nodiscard]] std::expected<Allocation, Error> internal_allocate_near(
-        const std::vector<uintptr_t>& desired_addresses, size_t size, size_t max_distance = 0x7FFF'FFFF);
-    void internal_free(uintptr_t address, size_t size);
+        const std::vector<uint8_t*>& desired_addresses, size_t size, size_t max_distance = 0x7FFF'FFFF);
+    void internal_free(uint8_t* address, size_t size);
 
     static void combine_adjacent_freenodes(Memory& memory);
-    [[nodiscard]] static std::expected<uintptr_t, Error> allocate_nearby_memory(
-        const std::vector<uintptr_t>& desired_addresses, size_t size, size_t max_distance);
+    [[nodiscard]] static std::expected<uint8_t*, Error> allocate_nearby_memory(
+        const std::vector<uint8_t*>& desired_addresses, size_t size, size_t max_distance);
     [[nodiscard]] static bool in_range(
-        uintptr_t address, const std::vector<uintptr_t>& desired_addresses, size_t max_distance);
+        uint8_t* address, const std::vector<uint8_t*>& desired_addresses, size_t max_distance);
 };
 } // namespace safetyhook

--- a/include/safetyhook/allocator.hpp
+++ b/include/safetyhook/allocator.hpp
@@ -26,9 +26,13 @@ public:
     /// @note This is called automatically when the Allocation object is destroyed.
     void free();
 
+    /// @brief Returns a pointer to the data of the allocation.
+    /// @return Pointer to the data of the allocation.
+    [[nodiscard]] uint8_t* data() const noexcept { return m_address; }
+
     /// @brief Returns the address of the allocation.
     /// @return The address of the allocation.
-    [[nodiscard]] uint8_t* address() const noexcept { return m_address; }
+    [[nodiscard]] uintptr_t address() const noexcept { return (uintptr_t)m_address; }
 
     /// @brief Returns the size of the allocation.
     /// @return The size of the allocation.

--- a/include/safetyhook/easy.hpp
+++ b/include/safetyhook/easy.hpp
@@ -11,23 +11,33 @@ namespace safetyhook {
 /// @param target The address of the function to hook.
 /// @param destination The address of the destination function.
 /// @return The InlineHook object.
-InlineHook create_inline(void* target, void* destination);
+[[nodiscard]] InlineHook create_inline(void* target, void* destination);
 
 /// @brief Easy to use API for creating an InlineHook.
+/// @tparam T The type of the function to hook.
 /// @param target The address of the function to hook.
 /// @param destination The address of the destination function.
 /// @return The InlineHook object.
-InlineHook create_inline(uintptr_t target, uintptr_t destination);
+template <typename T>
+    requires std::is_function_v<T>
+[[nodiscard]] InlineHook create_inline(T* target, T* destination) {
+    return create_inline(reinterpret_cast<void*>(target), reinterpret_cast<void*>(destination));
+}
 
 /// @brief Easy to use API for creating a MidHook.
 /// @param target the address of the function to hook.
 /// @param destination The destination function.
 /// @return The MidHook object.
-MidHook create_mid(void* target, MidHookFn destination);
+[[nodiscard]] MidHook create_mid(void* target, MidHookFn destination);
 
 /// @brief Easy to use API for creating a MidHook.
+/// @tparam T The type of the function to hook.
 /// @param target the address of the function to hook.
 /// @param destination The destination function.
 /// @return The MidHook object.
-MidHook create_mid(uintptr_t target, MidHookFn destination);
+template <typename T>
+    requires std::is_function_v<T>
+[[nodiscard]] MidHook create_mid(T* target, MidHookFn destination) {
+    return create_mid(reinterpret_cast<void*>(target), destination);
+}
 } // namespace safetyhook

--- a/include/safetyhook/inline_hook.hpp
+++ b/include/safetyhook/inline_hook.hpp
@@ -78,12 +78,17 @@ public:
     [[nodiscard]] static std::expected<InlineHook, Error> create(void* target, void* destination);
 
     /// @brief Create an inline hook.
+    /// @tparam T The type of the function to hook.
     /// @param target The address of the function to hook.
     /// @param destination The destination address.
     /// @return The InlineHook or an InlineHook::Error if an error occurred.
     /// @note This will use the default global Allocator.
     /// @note If you don't care about error handling, use the easy API (safetyhook::create_inline).
-    [[nodiscard]] static std::expected<InlineHook, Error> create(uintptr_t target, uintptr_t destination);
+    template <typename T>
+        requires std::is_function_v<T>
+    [[nodiscard]] static std::expected<InlineHook, Error> create(T* target, T* destination) {
+        return create(reinterpret_cast<void*>(target), reinterpret_cast<void*>(destination));
+    }
 
     /// @brief Create an inline hook with a given Allocator.
     /// @param allocator The allocator to use.
@@ -95,13 +100,18 @@ public:
         const std::shared_ptr<Allocator>& allocator, void* target, void* destination);
 
     /// @brief Create an inline hook with a given Allocator.
+    /// @tparam T The type of the function to hook.
     /// @param allocator The allocator to use.
     /// @param target The address of the function to hook.
     /// @param destination The destination address.
     /// @return The InlineHook or an InlineHook::Error if an error occurred.
     /// @note If you don't care about error handling, use the easy API (safetyhook::create_inline).
+    template <typename T>
+        requires std::is_function_v<T>
     [[nodiscard]] static std::expected<InlineHook, Error> create(
-        const std::shared_ptr<Allocator>& allocator, uintptr_t target, uintptr_t destination);
+        const std::shared_ptr<Allocator>& allocator, T* target, T* destination) {
+        return create(allocator, reinterpret_cast<void*>(target), reinterpret_cast<void*>(destination));
+    }
 
     InlineHook() = default;
     InlineHook(const InlineHook&) = delete;

--- a/include/safetyhook/inline_hook.hpp
+++ b/include/safetyhook/inline_hook.hpp
@@ -30,7 +30,7 @@ public:
         /// @brief Extra information about the error.
         union {
             Allocator::Error allocator_error; ///< Allocator error information.
-            uintptr_t ip;                     ///< IP of the problematic instruction.
+            uint8_t* ip;                      ///< IP of the problematic instruction.
         };
 
         /// @brief Create a BAD_ALLOCATION error.
@@ -43,28 +43,28 @@ public:
         /// @brief Create a FAILED_TO_DECODE_INSTRUCTION error.
         /// @param ip The IP of the problematic instruction.
         /// @return The new FAILED_TO_DECODE_INSTRUCTION error.
-        [[nodiscard]] static Error failed_to_decode_instruction(uintptr_t ip) {
+        [[nodiscard]] static Error failed_to_decode_instruction(uint8_t* ip) {
             return {.type = FAILED_TO_DECODE_INSTRUCTION, .ip = ip};
         }
 
         /// @brief Create a SHORT_JUMP_IN_TRAMPOLINE error.
         /// @param ip The IP of the problematic instruction.
         /// @return The new SHORT_JUMP_IN_TRAMPOLINE error.
-        [[nodiscard]] static Error short_jump_in_trampoline(uintptr_t ip) {
+        [[nodiscard]] static Error short_jump_in_trampoline(uint8_t* ip) {
             return {.type = SHORT_JUMP_IN_TRAMPOLINE, .ip = ip};
         }
 
         /// @brief Create a IP_RELATIVE_INSTRUCTION_OUT_OF_RANGE error.
         /// @param ip The IP of the problematic instruction.
         /// @return The new IP_RELATIVE_INSTRUCTION_OUT_OF_RANGE error.
-        [[nodiscard]] static Error ip_relative_instruction_out_of_range(uintptr_t ip) {
+        [[nodiscard]] static Error ip_relative_instruction_out_of_range(uint8_t* ip) {
             return {.type = IP_RELATIVE_INSTRUCTION_OUT_OF_RANGE, .ip = ip};
         }
 
         /// @brief Create a UNSUPPORTED_INSTRUCTION_IN_TRAMPOLINE error.
         /// @param ip The IP of the problematic instruction.
         /// @return The new UNSUPPORTED_INSTRUCTION_IN_TRAMPOLINE error.
-        [[nodiscard]] static Error unsupported_instruction_in_trampoline(uintptr_t ip) {
+        [[nodiscard]] static Error unsupported_instruction_in_trampoline(uint8_t* ip) {
             return {.type = UNSUPPORTED_INSTRUCTION_IN_TRAMPOLINE, .ip = ip};
         }
     };
@@ -117,11 +117,11 @@ public:
 
     /// @brief Get the target address.
     /// @return The target address.
-    [[nodiscard]] uintptr_t target() const { return m_target; }
+    [[nodiscard]] uint8_t* target() const { return m_target; }
 
     /// @brief Get the destination address.
     /// @return The destination address.
-    [[nodiscard]] size_t destination() const { return m_destination; }
+    [[nodiscard]] uint8_t* destination() const { return m_destination; }
 
     /// @brief Get the trampoline Allocation.
     /// @return The trampoline Allocation.
@@ -252,15 +252,15 @@ public:
     }
 
 private:
-    uintptr_t m_target{};
-    uintptr_t m_destination{};
+    uint8_t* m_target{};
+    uint8_t* m_destination{};
     Allocation m_trampoline{};
     std::vector<uint8_t> m_original_bytes{};
     uintptr_t m_trampoline_size{};
     std::recursive_mutex m_mutex{};
 
     std::expected<void, Error> setup(
-        const std::shared_ptr<Allocator>& allocator, uintptr_t target, uintptr_t destination);
+        const std::shared_ptr<Allocator>& allocator, uint8_t* target, uint8_t* destination);
     std::expected<void, Error> e9_hook(const std::shared_ptr<Allocator>& allocator);
 
 #ifdef _M_X64

--- a/include/safetyhook/inline_hook.hpp
+++ b/include/safetyhook/inline_hook.hpp
@@ -115,13 +115,21 @@ public:
     /// @note This is called automatically in the destructor.
     void reset();
 
+    /// @brief Get a pointer to the target.
+    /// @return A pointer to the target.
+    [[nodiscard]] uint8_t* target() const { return m_target; }
+
     /// @brief Get the target address.
     /// @return The target address.
-    [[nodiscard]] uint8_t* target() const { return m_target; }
+    [[nodiscard]] uintptr_t target_address() const { return reinterpret_cast<uintptr_t>(m_target); }
+
+    /// @brief Get a pointer ot the destination.
+    /// @return A pointer to the destination.
+    [[nodiscard]] uint8_t* destination() const { return m_destination; }
 
     /// @brief Get the destination address.
     /// @return The destination address.
-    [[nodiscard]] uint8_t* destination() const { return m_destination; }
+    [[nodiscard]] uintptr_t destination_address() const { return reinterpret_cast<uintptr_t>(m_destination); }
 
     /// @brief Get the trampoline Allocation.
     /// @return The trampoline Allocation.

--- a/include/safetyhook/mid_hook.hpp
+++ b/include/safetyhook/mid_hook.hpp
@@ -93,9 +93,13 @@ public:
     /// @note This is called automatically in the destructor.
     void reset();
 
-    /// @brief Get the target address.
-    /// @return The target address.
+    /// @brief Get a pointer to the target.
+    /// @return A pointer to the target.
     [[nodiscard]] uint8_t* target() const { return m_target; }
+
+    /// @brief Get the address of the target.
+    /// @return The address of the target.
+    [[nodiscard]] uintptr_t target_address() const { return reinterpret_cast<uintptr_t>(m_target); }
 
     /// @brief Get the destination function.
     /// @return The destination function.

--- a/include/safetyhook/mid_hook.hpp
+++ b/include/safetyhook/mid_hook.hpp
@@ -56,12 +56,17 @@ public:
     [[nodiscard]] static std::expected<MidHook, Error> create(void* target, MidHookFn destination);
 
     /// @brief Creates a new MidHook object.
+    /// @tparam T The type of the function to hook.
     /// @param target The address of the function to hook.
     /// @param destination The destination function.
     /// @return The MidHook object or a MidHook::Error if an error occurred.
     /// @note This will use the default global Allocator.
     /// @note If you don't care about error handling, use the easy API (safetyhook::create_mid).
-    [[nodiscard]] static std::expected<MidHook, Error> create(uintptr_t target, MidHookFn destination);
+    template <typename T>
+        requires std::is_function_v<T>
+    [[nodiscard]] static std::expected<MidHook, Error> create(T* target, MidHookFn destination) {
+        return create(reinterpret_cast<void*>(target), destination);
+    }
 
     /// @brief Creates a new MidHook object with a given Allocator.
     /// @param allocator The Allocator to use.
@@ -73,13 +78,18 @@ public:
         const std::shared_ptr<Allocator>& allocator, void* target, MidHookFn destination);
 
     /// @brief Creates a new MidHook object with a given Allocator.
+    /// @tparam T The type of the function to hook.
     /// @param allocator The Allocator to use.
     /// @param target The address of the function to hook.
     /// @param destination The destination function.
     /// @return The MidHook object or a MidHook::Error if an error occurred.
     /// @note If you don't care about error handling, use the easy API (safetyhook::create_mid).
+    template <typename T>
+        requires std::is_function_v<T>
     [[nodiscard]] static std::expected<MidHook, Error> create(
-        const std::shared_ptr<Allocator>& allocator, uintptr_t target, MidHookFn destination);
+        const std::shared_ptr<Allocator>& allocator, T* target, MidHookFn destination) {
+        return create(allocator, reinterpret_cast<void*>(target), destination);
+    }
 
     MidHook() = default;
     MidHook(const MidHook&) = delete;

--- a/include/safetyhook/mid_hook.hpp
+++ b/include/safetyhook/mid_hook.hpp
@@ -95,7 +95,7 @@ public:
 
     /// @brief Get the target address.
     /// @return The target address.
-    [[nodiscard]] uintptr_t target() const { return m_target; }
+    [[nodiscard]] uint8_t* target() const { return m_target; }
 
     /// @brief Get the destination function.
     /// @return The destination function.
@@ -107,11 +107,11 @@ public:
 
 private:
     InlineHook m_hook{};
-    uintptr_t m_target{};
+    uint8_t* m_target{};
     Allocation m_stub{};
     MidHookFn m_destination{};
 
     std::expected<void, Error> setup(
-        const std::shared_ptr<Allocator>& allocator, uintptr_t target, MidHookFn destination);
+        const std::shared_ptr<Allocator>& allocator, uint8_t* target, MidHookFn destination);
 };
 } // namespace safetyhook

--- a/include/safetyhook/thread_freezer.hpp
+++ b/include/safetyhook/thread_freezer.hpp
@@ -24,5 +24,5 @@ void execute_while_frozen(
 /// @param ctx The thread context to modify.
 /// @param old_ip The old IP address.
 /// @param new_ip The new IP address.
-void fix_ip(CONTEXT& ctx, uintptr_t old_ip, uintptr_t new_ip);
+void fix_ip(CONTEXT& ctx, uint8_t* old_ip, uint8_t* new_ip);
 } // namespace safetyhook

--- a/include/safetyhook/utility.hpp
+++ b/include/safetyhook/utility.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <cstdint>
+
+namespace safetyhook {
+template <typename T> constexpr void store(uint8_t* address, const T& value) {
+    const auto data = reinterpret_cast<const uint8_t*>(&value);
+
+    // Write each byte out individually to avoid undefined behavior.
+    for (size_t i = 0; i < sizeof(T); ++i) {
+        address[i] = data[i];
+    }
+}
+} // namespace safetyhook

--- a/include/safetyhook/utility.hpp
+++ b/include/safetyhook/utility.hpp
@@ -1,14 +1,10 @@
 #pragma once
 
+#include <algorithm>
 #include <cstdint>
 
 namespace safetyhook {
 template <typename T> constexpr void store(uint8_t* address, const T& value) {
-    const auto data = reinterpret_cast<const uint8_t*>(&value);
-
-    // Write each byte out individually to avoid undefined behavior.
-    for (size_t i = 0; i < sizeof(T); ++i) {
-        address[i] = data[i];
-    }
+    std::copy_n(reinterpret_cast<const uint8_t*>(&value), sizeof(T), address);
 }
 } // namespace safetyhook

--- a/src/easy.cpp
+++ b/src/easy.cpp
@@ -2,10 +2,6 @@
 
 namespace safetyhook {
 InlineHook create_inline(void* target, void* destination) {
-    return create_inline(reinterpret_cast<uintptr_t>(target), reinterpret_cast<uintptr_t>(destination));
-}
-
-InlineHook create_inline(uintptr_t target, uintptr_t destination) {
     if (auto hook = InlineHook::create(target, destination)) {
         return std::move(*hook);
     } else {
@@ -14,14 +10,11 @@ InlineHook create_inline(uintptr_t target, uintptr_t destination) {
 }
 
 MidHook create_mid(void* target, MidHookFn destination) {
-    return create_mid(reinterpret_cast<uintptr_t>(target), destination);
-}
-
-MidHook create_mid(uintptr_t target, MidHookFn destination) {
     if (auto hook = MidHook::create(target, destination)) {
         return std::move(*hook);
     } else {
         return {};
     }
 }
+
 } // namespace safetyhook

--- a/src/inline_hook.cpp
+++ b/src/inline_hook.cpp
@@ -132,17 +132,8 @@ std::expected<InlineHook, InlineHook::Error> InlineHook::create(void* target, vo
     return create(Allocator::global(), target, destination);
 }
 
-std::expected<InlineHook, InlineHook::Error> InlineHook::create(uintptr_t target, uintptr_t destination) {
-    return create(Allocator::global(), target, destination);
-}
-
 std::expected<InlineHook, InlineHook::Error> InlineHook::create(
     const std::shared_ptr<Allocator>& allocator, void* target, void* destination) {
-    return create(allocator, reinterpret_cast<uintptr_t>(target), reinterpret_cast<uintptr_t>(destination));
-}
-
-std::expected<InlineHook, InlineHook::Error> InlineHook::create(
-    const std::shared_ptr<Allocator>& allocator, uintptr_t target, uintptr_t destination) {
     InlineHook hook{};
 
     if (const auto setup_result =

--- a/src/inline_hook.cpp
+++ b/src/inline_hook.cpp
@@ -18,14 +18,14 @@
 namespace safetyhook {
 class UnprotectMemory {
 public:
-    UnprotectMemory(uintptr_t address, size_t size) : m_address{address}, m_size{size} {
-        VirtualProtect(reinterpret_cast<LPVOID>(m_address), m_size, PAGE_EXECUTE_READWRITE, &m_protect);
+    UnprotectMemory(uint8_t* address, size_t size) : m_address{address}, m_size{size} {
+        VirtualProtect(m_address, m_size, PAGE_EXECUTE_READWRITE, &m_protect);
     }
 
-    ~UnprotectMemory() { VirtualProtect(reinterpret_cast<LPVOID>(m_address), m_size, m_protect, &m_protect); }
+    ~UnprotectMemory() { VirtualProtect(m_address, m_size, m_protect, &m_protect); }
 
 private:
-    uintptr_t m_address{};
+    uint8_t* m_address{};
     size_t m_size{};
     DWORD m_protect{};
 };
@@ -62,16 +62,16 @@ struct TrampolineEpilogueE9 {
 #pragma pack(pop)
 
 #ifdef _M_X64
-static auto make_jmp_ff(uintptr_t src, uintptr_t dst, uintptr_t data) {
+static auto make_jmp_ff(uint8_t* src, uint8_t* dst, uint8_t* data) {
     JmpFF jmp{};
 
     jmp.offset = static_cast<uint32_t>(data - src - sizeof(jmp));
-    *reinterpret_cast<uintptr_t*>(data) = dst;
+    *reinterpret_cast<uint8_t**>(data) = dst;
 
     return jmp;
 }
 
-static void emit_jmp_ff(uintptr_t src, uintptr_t dst, uintptr_t data, size_t size = sizeof(JmpFF)) {
+static void emit_jmp_ff(uint8_t* src, uint8_t* dst, uint8_t* data, size_t size = sizeof(JmpFF)) {
     if (size < sizeof(JmpFF)) {
         return;
     }
@@ -79,14 +79,14 @@ static void emit_jmp_ff(uintptr_t src, uintptr_t dst, uintptr_t data, size_t siz
     UnprotectMemory unprotect{src, size};
 
     if (size > sizeof(JmpFF)) {
-        std::fill_n(reinterpret_cast<uint8_t*>(src), size, static_cast<uint8_t>(0x90));
+        std::fill_n(src, size, static_cast<uint8_t>(0x90));
     }
 
     *reinterpret_cast<JmpFF*>(src) = make_jmp_ff(src, dst, data);
 }
 #endif
 
-constexpr auto make_jmp_e9(uintptr_t src, uintptr_t dst) {
+constexpr auto make_jmp_e9(uint8_t* src, uint8_t* dst) {
     JmpE9 jmp{};
 
     jmp.offset = static_cast<uint32_t>(dst - src - sizeof(jmp));
@@ -94,7 +94,7 @@ constexpr auto make_jmp_e9(uintptr_t src, uintptr_t dst) {
     return jmp;
 }
 
-static void emit_jmp_e9(uintptr_t src, uintptr_t dst, size_t size = sizeof(JmpE9)) {
+static void emit_jmp_e9(uint8_t* src, uint8_t* dst, size_t size = sizeof(JmpE9)) {
     if (size < sizeof(JmpE9)) {
         return;
     }
@@ -102,13 +102,13 @@ static void emit_jmp_e9(uintptr_t src, uintptr_t dst, size_t size = sizeof(JmpE9
     UnprotectMemory unprotect{src, size};
 
     if (size > sizeof(JmpE9)) {
-        std::fill_n(reinterpret_cast<uint8_t*>(src), size, static_cast<uint8_t>(0x90));
+        std::fill_n(src, size, static_cast<uint8_t>(0x90));
     }
 
     *reinterpret_cast<JmpE9*>(src) = make_jmp_e9(src, dst);
 }
 
-static bool decode(ZydisDecodedInstruction* ix, uintptr_t ip) {
+static bool decode(ZydisDecodedInstruction* ix, uint8_t* ip) {
     ZydisDecoder decoder{};
     ZyanStatus status;
 
@@ -124,7 +124,7 @@ static bool decode(ZydisDecodedInstruction* ix, uintptr_t ip) {
         return false;
     }
 
-    return ZYAN_SUCCESS(ZydisDecoderDecodeInstruction(&decoder, nullptr, reinterpret_cast<const void*>(ip), 15, ix));
+    return ZYAN_SUCCESS(ZydisDecoderDecodeInstruction(&decoder, nullptr, ip, 15, ix));
 }
 
 std::expected<InlineHook, InlineHook::Error> InlineHook::create(void* target, void* destination) {
@@ -144,7 +144,9 @@ std::expected<InlineHook, InlineHook::Error> InlineHook::create(
     const std::shared_ptr<Allocator>& allocator, uintptr_t target, uintptr_t destination) {
     InlineHook hook{};
 
-    if (const auto setup_result = hook.setup(allocator, target, destination); !setup_result) {
+    if (const auto setup_result =
+            hook.setup(allocator, reinterpret_cast<uint8_t*>(target), reinterpret_cast<uint8_t*>(destination));
+        !setup_result) {
         return std::unexpected{setup_result.error()};
     }
 
@@ -184,13 +186,13 @@ void InlineHook::reset() {
 }
 
 std::expected<void, InlineHook::Error> InlineHook::setup(
-    const std::shared_ptr<Allocator>& allocator, uintptr_t target, uintptr_t destination) {
+    const std::shared_ptr<Allocator>& allocator, uint8_t* target, uint8_t* destination) {
     m_target = target;
     m_destination = destination;
 
-    if (const auto e9_result = e9_hook(allocator); !e9_result) {
+    if (auto e9_result = e9_hook(allocator); !e9_result) {
 #ifdef _M_X64
-        if (const auto ff_result = ff_hook(allocator); !ff_result) {
+        if (auto ff_result = ff_hook(allocator); !ff_result) {
             return ff_result;
         }
 #else
@@ -205,17 +207,16 @@ std::expected<void, InlineHook::Error> InlineHook::e9_hook(const std::shared_ptr
     m_original_bytes.clear();
     m_trampoline_size = sizeof(TrampolineEpilogueE9);
 
-    std::vector<uintptr_t> desired_addresses{m_target};
+    std::vector<uint8_t*> desired_addresses{m_target};
     ZydisDecodedInstruction ix{};
 
-    for (uintptr_t ip = m_target; ip < m_target + sizeof(JmpE9); ip += ix.length) {
+    for (auto ip = m_target; ip < m_target + sizeof(JmpE9); ip += ix.length) {
         if (!decode(&ix, ip)) {
             return std::unexpected{Error::failed_to_decode_instruction(ip)};
         }
 
         m_trampoline_size += ix.length;
-        m_original_bytes.insert(
-            m_original_bytes.end(), reinterpret_cast<uint8_t*>(ip), reinterpret_cast<uint8_t*>(ip) + ix.length);
+        m_original_bytes.insert(m_original_bytes.end(), ip, ip + ix.length);
 
         const auto is_relative = (ix.attributes & ZYDIS_ATTRIB_IS_RELATIVE) != 0;
 
@@ -248,7 +249,7 @@ std::expected<void, InlineHook::Error> InlineHook::e9_hook(const std::shared_ptr
 
     m_trampoline = std::move(*trampoline_allocation);
 
-    for (uintptr_t ip = m_target, tramp_ip = m_trampoline.address(); ip < m_target + m_original_bytes.size();
+    for (auto ip = m_target, tramp_ip = m_trampoline.address(); ip < m_target + m_original_bytes.size();
          ip += ix.length) {
         if (!decode(&ix, ip)) {
             m_trampoline.free();
@@ -258,44 +259,44 @@ std::expected<void, InlineHook::Error> InlineHook::e9_hook(const std::shared_ptr
         const auto is_relative = (ix.attributes & ZYDIS_ATTRIB_IS_RELATIVE) != 0;
 
         if (is_relative && ix.raw.disp.size == 32) {
-            std::copy_n(reinterpret_cast<uint8_t*>(ip), ix.length, reinterpret_cast<uint8_t*>(tramp_ip));
-            const auto target_address = ip + ix.length + static_cast<int32_t>(ix.raw.disp.value);
-            const auto new_disp = static_cast<int32_t>(target_address - (tramp_ip + ix.length));
-            *reinterpret_cast<int32_t*>(tramp_ip + ix.raw.disp.offset) = new_disp;
+            std::copy_n(ip, ix.length, tramp_ip);
+            const auto target_address = ip + ix.length + ix.raw.disp.value;
+            const auto new_disp = target_address - (tramp_ip + ix.length);
+            *reinterpret_cast<int32_t*>(tramp_ip + ix.raw.disp.offset) = static_cast<int32_t>(new_disp);
             tramp_ip += ix.length;
         } else if (is_relative && ix.raw.imm[0].size == 32) {
-            std::copy_n(reinterpret_cast<uint8_t*>(ip), ix.length, reinterpret_cast<uint8_t*>(tramp_ip));
-            const auto target_address = ip + ix.length + static_cast<int32_t>(ix.raw.imm[0].value.s);
-            const auto new_disp = static_cast<int32_t>(target_address - (tramp_ip + ix.length));
-            *reinterpret_cast<int32_t*>(tramp_ip + ix.raw.imm[0].offset) = new_disp;
+            std::copy_n(ip, ix.length, tramp_ip);
+            const auto target_address = ip + ix.length + ix.raw.imm[0].value.s;
+            const auto new_disp = target_address - (tramp_ip + ix.length);
+            *reinterpret_cast<int32_t*>(tramp_ip + ix.raw.imm[0].offset) = static_cast<int32_t>(new_disp);
             tramp_ip += ix.length;
         } else if (ix.meta.category == ZYDIS_CATEGORY_COND_BR && ix.meta.branch_type == ZYDIS_BRANCH_TYPE_SHORT) {
-            const auto target_address = ip + ix.length + static_cast<int32_t>(ix.raw.imm[0].value.s);
-            auto new_disp = static_cast<int32_t>(target_address - (tramp_ip + 6));
+            const auto target_address = ip + ix.length + ix.raw.imm[0].value.s;
+            auto new_disp = target_address - (tramp_ip + 6);
 
             // Handle the case where the target is now in the trampoline.
             if (target_address < m_target + m_original_bytes.size()) {
-                new_disp = static_cast<int32_t>(ix.raw.imm[0].value.s);
+                new_disp = static_cast<ptrdiff_t>(ix.raw.imm[0].value.s);
             }
 
-            *reinterpret_cast<uint8_t*>(tramp_ip) = 0x0F;
-            *reinterpret_cast<uint8_t*>(tramp_ip + 1) = 0x10 + ix.opcode;
-            *reinterpret_cast<int32_t*>(tramp_ip + 2) = new_disp;
+            *tramp_ip = 0x0F;
+            *(tramp_ip + 1) = 0x10 + ix.opcode;
+            *reinterpret_cast<int32_t*>(tramp_ip + 2) = static_cast<int32_t>(new_disp);
             tramp_ip += 6;
         } else if (ix.meta.category == ZYDIS_CATEGORY_UNCOND_BR && ix.meta.branch_type == ZYDIS_BRANCH_TYPE_SHORT) {
-            const auto target_address = ip + ix.length + static_cast<int32_t>(ix.raw.imm[0].value.s);
-            auto new_disp = static_cast<int32_t>(target_address - (tramp_ip + 5));
+            const auto target_address = ip + ix.length + ix.raw.imm[0].value.s;
+            auto new_disp = target_address - (tramp_ip + 5);
 
             // Handle the case where the target is now in the trampoline.
             if (target_address < m_target + m_original_bytes.size()) {
-                new_disp = static_cast<int32_t>(ix.raw.imm[0].value.s);
+                new_disp = static_cast<ptrdiff_t>(ix.raw.imm[0].value.s);
             }
 
-            *reinterpret_cast<uint8_t*>(tramp_ip) = 0xE9;
-            *reinterpret_cast<int32_t*>(tramp_ip + 1) = new_disp;
+            *tramp_ip = 0xE9;
+            *reinterpret_cast<int32_t*>(tramp_ip + 1) = static_cast<int32_t>(new_disp);
             tramp_ip += 5;
         } else {
-            std::copy_n(reinterpret_cast<uint8_t*>(ip), ix.length, reinterpret_cast<uint8_t*>(tramp_ip));
+            std::copy_n(ip, ix.length, tramp_ip);
             tramp_ip += ix.length;
         }
     }
@@ -304,16 +305,16 @@ std::expected<void, InlineHook::Error> InlineHook::e9_hook(const std::shared_ptr
         m_trampoline.address() + m_trampoline_size - sizeof(TrampolineEpilogueE9));
 
     // jmp from trampoline to original.
-    auto src = reinterpret_cast<uintptr_t>(&trampoline_epilogue->jmp_to_original);
+    auto src = reinterpret_cast<uint8_t*>(&trampoline_epilogue->jmp_to_original);
     auto dst = m_target + m_original_bytes.size();
     emit_jmp_e9(src, dst);
 
     // jmp from trampoline to destination.
-    src = reinterpret_cast<uintptr_t>(&trampoline_epilogue->jmp_to_destination);
+    src = reinterpret_cast<uint8_t*>(&trampoline_epilogue->jmp_to_destination);
     dst = m_destination;
 
 #ifdef _M_X64
-    auto data = reinterpret_cast<uintptr_t>(&trampoline_epilogue->destination_address);
+    auto data = reinterpret_cast<uint8_t*>(&trampoline_epilogue->destination_address);
     emit_jmp_ff(src, dst, data);
 #else
     emit_jmp_e9(src, dst);
@@ -323,7 +324,7 @@ std::expected<void, InlineHook::Error> InlineHook::e9_hook(const std::shared_ptr
     execute_while_frozen(
         [this, &trampoline_epilogue] {
             const auto src = m_target;
-            const auto dst = reinterpret_cast<uintptr_t>(&trampoline_epilogue->jmp_to_destination);
+            const auto dst = reinterpret_cast<uint8_t*>(&trampoline_epilogue->jmp_to_destination);
             emit_jmp_e9(src, dst, m_original_bytes.size());
         },
         [this](uint32_t, HANDLE, CONTEXT& ctx) {
@@ -353,8 +354,7 @@ std::expected<void, InlineHook::Error> InlineHook::ff_hook(const std::shared_ptr
             return std::unexpected{Error::ip_relative_instruction_out_of_range(ip)};
         }
 
-        m_original_bytes.insert(
-            m_original_bytes.end(), reinterpret_cast<uint8_t*>(ip), reinterpret_cast<uint8_t*>(ip + ix.length));
+        m_original_bytes.insert(m_original_bytes.end(), ip, ip + ix.length);
         m_trampoline_size += ix.length;
     }
 
@@ -366,15 +366,15 @@ std::expected<void, InlineHook::Error> InlineHook::ff_hook(const std::shared_ptr
 
     m_trampoline = std::move(*trampoline_allocation);
 
-    std::copy(m_original_bytes.begin(), m_original_bytes.end(), reinterpret_cast<uint8_t*>(m_trampoline.address()));
+    std::copy(m_original_bytes.begin(), m_original_bytes.end(), m_trampoline.address());
 
     const auto trampoline_epilogue = reinterpret_cast<TrampolineEpilogueFF*>(
         m_trampoline.address() + m_trampoline_size - sizeof(TrampolineEpilogueFF));
 
     // jmp from trampoline to original.
-    auto src = reinterpret_cast<uintptr_t>(&trampoline_epilogue->jmp_to_original);
+    auto src = reinterpret_cast<uint8_t*>(&trampoline_epilogue->jmp_to_original);
     auto dst = m_target + m_original_bytes.size();
-    auto data = reinterpret_cast<uintptr_t>(&trampoline_epilogue->original_address);
+    auto data = reinterpret_cast<uint8_t*>(&trampoline_epilogue->original_address);
     emit_jmp_ff(src, dst, data);
 
     // jmp from original to trampoline.
@@ -405,7 +405,7 @@ void InlineHook::destroy() {
     execute_while_frozen(
         [this] {
             UnprotectMemory unprotect{m_target, m_original_bytes.size()};
-            std::copy(m_original_bytes.begin(), m_original_bytes.end(), reinterpret_cast<uint8_t*>(m_target));
+            std::copy(m_original_bytes.begin(), m_original_bytes.end(), m_target);
         },
         [this](uint32_t, HANDLE, CONTEXT& ctx) {
             for (size_t i = 0; i < m_original_bytes.size(); ++i) {

--- a/src/mid_hook.cpp
+++ b/src/mid_hook.cpp
@@ -25,17 +25,8 @@ std::expected<MidHook, MidHook::Error> MidHook::create(void* target, MidHookFn d
     return create(Allocator::global(), target, destination);
 }
 
-std::expected<MidHook, MidHook::Error> MidHook::create(uintptr_t target, MidHookFn destination) {
-    return create(Allocator::global(), target, destination);
-}
-
 std::expected<MidHook, MidHook::Error> MidHook::create(
     const std::shared_ptr<Allocator>& allocator, void* target, MidHookFn destination) {
-    return create(allocator, reinterpret_cast<uintptr_t>(target), destination);
-}
-
-std::expected<MidHook, MidHook::Error> MidHook::create(
-    const std::shared_ptr<Allocator>& allocator, uintptr_t target, MidHookFn destination) {
     MidHook hook{};
 
     if (const auto setup_result = hook.setup(allocator, reinterpret_cast<uint8_t*>(target), destination);

--- a/src/mid_hook.cpp
+++ b/src/mid_hook.cpp
@@ -81,19 +81,19 @@ std::expected<void, MidHook::Error> MidHook::setup(
 
     m_stub = std::move(*stub_allocation);
 
-    std::copy_n(asm_data, sizeof(asm_data), reinterpret_cast<uint8_t*>(m_stub.address()));
+    std::copy_n(asm_data, sizeof(asm_data), m_stub.data());
 
 #ifdef _M_X64
-    store(m_stub.address() + sizeof(asm_data) - 16, m_destination);
+    store(m_stub.data() + sizeof(asm_data) - 16, m_destination);
 #else
-    store(m_stub.address() + sizeof(asm_data) - 8, m_destination);
+    store(m_stub.data() + sizeof(asm_data) - 8, m_destination);
 
     // 32-bit has some relocations we need to fix up as well.
-    store(m_stub.address() + 0xA + 2, m_stub.address() + sizeof(asm_data) - 8);
-    store(m_stub.address() + 0x1C + 2, m_stub.address() + sizeof(asm_data) - 4);
+    store(m_stub.data() + 0xA + 2, m_stub.data() + sizeof(asm_data) - 8);
+    store(m_stub.data() + 0x1C + 2, m_stub.data() + sizeof(asm_data) - 4);
 #endif
 
-    auto hook_result = InlineHook::create(allocator, m_target, m_stub.address());
+    auto hook_result = InlineHook::create(allocator, m_target, m_stub.data());
 
     if (!hook_result) {
         m_stub.free();
@@ -103,9 +103,9 @@ std::expected<void, MidHook::Error> MidHook::setup(
     m_hook = std::move(*hook_result);
 
 #ifdef _M_X64
-    store(m_stub.address() + sizeof(asm_data) - 8, m_hook.trampoline().address());
+    store(m_stub.data() + sizeof(asm_data) - 8, m_hook.trampoline().data());
 #else
-    store(m_stub.address() + sizeof(asm_data) - 4, m_hook.trampoline().address());
+    store(m_stub.data() + sizeof(asm_data) - 4, m_hook.trampoline().data());
 #endif
 
     return {};

--- a/src/thread_freezer.cpp
+++ b/src/thread_freezer.cpp
@@ -110,15 +110,15 @@ void execute_while_frozen(
     }
 }
 
-void fix_ip(CONTEXT& ctx, uintptr_t old_ip, uintptr_t new_ip) {
+void fix_ip(CONTEXT& ctx, uint8_t* old_ip, uint8_t* new_ip) {
 #ifdef _M_X64
     auto ip = ctx.Rip;
 #else
     auto ip = ctx.Eip;
 #endif
 
-    if (ip == old_ip) {
-        ip = new_ip;
+    if (ip == reinterpret_cast<uintptr_t>(old_ip)) {
+        ip = reinterpret_cast<uintptr_t>(new_ip);
     }
 
 #ifdef _M_X64

--- a/tests/test2.cpp
+++ b/tests/test2.cpp
@@ -38,9 +38,9 @@ int main() {
 #error "Unsupported architecture"
 #endif
 
-    auto ip = (uintptr_t)add_42;
+    auto ip = reinterpret_cast<uint8_t*>(add_42);
 
-    while (*(uint8_t*)ip != 0xC3) {
+    while (*ip != 0xC3) {
         ZydisDecodedInstruction ix{};
 
         ZydisDecoderDecodeInstruction(&decoder, nullptr, reinterpret_cast<void*>(ip), 15, &ix);

--- a/unittest/inline_hook.cpp
+++ b/unittest/inline_hook.cpp
@@ -1,6 +1,6 @@
 #include <catch2/catch_test_macros.hpp>
-#include <xbyak/xbyak.h>
 #include <safetyhook.hpp>
+#include <xbyak/xbyak.h>
 
 TEST_CASE("Function hooked multiple times", "[inline_hook]") {
     struct Target {
@@ -16,7 +16,7 @@ TEST_CASE("Function hooked multiple times", "[inline_hook]") {
         static std::string fn(std::string name) { return hook0.call<std::string>(name + " and bob"); }
     };
 
-    auto hook0_result = SafetyHookInline::create(reinterpret_cast<void*>(Target::fn), reinterpret_cast<void*>(Hook0::fn));
+    auto hook0_result = SafetyHookInline::create(Target::fn, Hook0::fn);
 
     REQUIRE(hook0_result);
 
@@ -31,7 +31,7 @@ TEST_CASE("Function hooked multiple times", "[inline_hook]") {
         static std::string fn(std::string name) { return hook1.call<std::string>(name + " and alice"); }
     };
 
-    auto hook1_result = SafetyHookInline::create(reinterpret_cast<void*>(Target::fn), reinterpret_cast<void*>(Hook1::fn));
+    auto hook1_result = SafetyHookInline::create(Target::fn, Hook1::fn);
 
     REQUIRE(hook1_result);
 
@@ -46,7 +46,7 @@ TEST_CASE("Function hooked multiple times", "[inline_hook]") {
         static std::string fn(std::string name) { return hook2.call<std::string>(name + " and eve"); }
     };
 
-    auto hook2_result = SafetyHookInline::create(reinterpret_cast<void*>(Target::fn), reinterpret_cast<void*>(Hook2::fn));
+    auto hook2_result = SafetyHookInline::create(Target::fn, Hook2::fn);
 
     REQUIRE(hook2_result);
 
@@ -61,7 +61,7 @@ TEST_CASE("Function hooked multiple times", "[inline_hook]") {
         static std::string fn(std::string name) { return hook3.call<std::string>(name + " and carol"); }
     };
 
-    auto hook3_result = SafetyHookInline::create(reinterpret_cast<void*>(Target::fn), reinterpret_cast<void*>(Hook3::fn));
+    auto hook3_result = SafetyHookInline::create(Target::fn, Hook3::fn);
 
     REQUIRE(hook3_result);
 
@@ -89,7 +89,7 @@ TEST_CASE("Function with multiple args hooked", "[inline_hook]") {
         static int add(int x, int y) { return add_hook.call<int>(x * 2, y * 2); }
     };
 
-    auto add_hook_result = SafetyHookInline::create(reinterpret_cast<void*>(Target::add), reinterpret_cast<void*>(AddHook::add));
+    auto add_hook_result = SafetyHookInline::create(Target::add, AddHook::add);
 
     REQUIRE(add_hook_result);
 
@@ -128,7 +128,7 @@ TEST_CASE("Active function is hooked and unhooked", "[inline_hook]") {
         static std::string say_hello(int times [[maybe_unused]]) { return hook.call<std::string>(1337); }
     };
 
-    auto hook_result = SafetyHookInline::create(reinterpret_cast<void*>(Target::say_hello), reinterpret_cast<void*>(Hook::say_hello));
+    auto hook_result = SafetyHookInline::create(Target::say_hello, Hook::say_hello);
 
     REQUIRE(hook_result);
 
@@ -153,9 +153,7 @@ TEST_CASE("Function with short unconditional branch is hooked", "[inline-hook]")
     static SafetyHookInline hook;
 
     struct Hook {
-        static int __fastcall fn() { 
-            return hook.fastcall<int>() + 42; 
-        };
+        static int __fastcall fn() { return hook.fastcall<int>() + 42; };
     };
 
     Xbyak::CodeGenerator cg{};
@@ -173,7 +171,7 @@ TEST_CASE("Function with short unconditional branch is hooked", "[inline-hook]")
 
     REQUIRE(fn() == 1);
 
-    hook = safetyhook::create_inline(reinterpret_cast<void*>(fn), reinterpret_cast<void*>(Hook::fn));
+    hook = safetyhook::create_inline(fn, Hook::fn);
 
     REQUIRE(fn() == 43);
 
@@ -189,9 +187,7 @@ TEST_CASE("Function with short conditional branch is hooked", "[inline-hook]") {
     static SafetyHookInline hook;
 
     struct Hook {
-        static int __fastcall fn(int x) { 
-            return hook.fastcall<int>(x) + 42; 
-        };
+        static int __fastcall fn(int x) { return hook.fastcall<int>(x) + 42; };
     };
 
     Xbyak::CodeGenerator cg{};
@@ -217,7 +213,7 @@ TEST_CASE("Function with short conditional branch is hooked", "[inline-hook]") {
         CHECK(fn(8) == 0);
         CHECK(fn(9) == 0);
 
-        hook = safetyhook::create_inline(reinterpret_cast<void*>(fn), reinterpret_cast<void*>(Hook::fn));
+        hook = safetyhook::create_inline(fn, Hook::fn);
 
         CHECK(fn(7) == 43);
         CHECK(fn(8) == 42);
@@ -238,7 +234,7 @@ TEST_CASE("Function with short conditional branch is hooked", "[inline-hook]") {
         CHECK(fn(8) == 1);
         CHECK(fn(9) == 0);
 
-        hook = safetyhook::create_inline(reinterpret_cast<void*>(fn), reinterpret_cast<void*>(Hook::fn));
+        hook = safetyhook::create_inline(fn, Hook::fn);
 
         CHECK(fn(7) == 43);
         CHECK(fn(8) == 43);
@@ -259,7 +255,7 @@ TEST_CASE("Function with short conditional branch is hooked", "[inline-hook]") {
         CHECK(fn(8) == 0);
         CHECK(fn(9) == 0);
 
-        hook = safetyhook::create_inline(reinterpret_cast<void*>(fn), reinterpret_cast<void*>(Hook::fn));
+        hook = safetyhook::create_inline(fn, Hook::fn);
 
         CHECK(fn(7) == 43);
         CHECK(fn(8) == 42);
@@ -280,7 +276,7 @@ TEST_CASE("Function with short conditional branch is hooked", "[inline-hook]") {
         CHECK(fn(8) == 1);
         CHECK(fn(9) == 0);
 
-        hook = safetyhook::create_inline(reinterpret_cast<void*>(fn), reinterpret_cast<void*>(Hook::fn));
+        hook = safetyhook::create_inline(fn, Hook::fn);
 
         CHECK(fn(7) == 43);
         CHECK(fn(8) == 43);
@@ -301,7 +297,7 @@ TEST_CASE("Function with short conditional branch is hooked", "[inline-hook]") {
         CHECK(fn(8) == 1);
         CHECK(fn(9) == 1);
 
-        hook = safetyhook::create_inline(reinterpret_cast<void*>(fn), reinterpret_cast<void*>(Hook::fn));
+        hook = safetyhook::create_inline(fn, Hook::fn);
 
         CHECK(fn(7) == 42);
         CHECK(fn(8) == 43);
@@ -322,7 +318,7 @@ TEST_CASE("Function with short conditional branch is hooked", "[inline-hook]") {
         CHECK(fn(8) == 0);
         CHECK(fn(9) == 1);
 
-        hook = safetyhook::create_inline(reinterpret_cast<void*>(fn), reinterpret_cast<void*>(Hook::fn));
+        hook = safetyhook::create_inline(fn, Hook::fn);
 
         CHECK(fn(7) == 42);
         CHECK(fn(8) == 42);
@@ -343,7 +339,7 @@ TEST_CASE("Function with short conditional branch is hooked", "[inline-hook]") {
         CHECK(fn(8) == 1);
         CHECK(fn(9) == 1);
 
-        hook = safetyhook::create_inline(reinterpret_cast<void*>(fn), reinterpret_cast<void*>(Hook::fn));
+        hook = safetyhook::create_inline(fn, Hook::fn);
 
         CHECK(fn(7) == 42);
         CHECK(fn(8) == 43);
@@ -364,7 +360,7 @@ TEST_CASE("Function with short conditional branch is hooked", "[inline-hook]") {
         CHECK(fn(8) == 0);
         CHECK(fn(9) == 1);
 
-        hook = safetyhook::create_inline(reinterpret_cast<void*>(fn), reinterpret_cast<void*>(Hook::fn));
+        hook = safetyhook::create_inline(fn, Hook::fn);
 
         CHECK(fn(7) == 42);
         CHECK(fn(8) == 42);
@@ -385,7 +381,7 @@ TEST_CASE("Function with short conditional branch is hooked", "[inline-hook]") {
         CHECK(fn(8) == 1);
         CHECK(fn(9) == 1);
 
-        hook = safetyhook::create_inline(reinterpret_cast<void*>(fn), reinterpret_cast<void*>(Hook::fn));
+        hook = safetyhook::create_inline(fn, Hook::fn);
 
         CHECK(fn(7) == 43);
         CHECK(fn(8) == 43);
@@ -406,7 +402,7 @@ TEST_CASE("Function with short conditional branch is hooked", "[inline-hook]") {
         CHECK(fn(8) == 0);
         CHECK(fn(9) == 1);
 
-        hook = safetyhook::create_inline(reinterpret_cast<void*>(fn), reinterpret_cast<void*>(Hook::fn));
+        hook = safetyhook::create_inline(fn, Hook::fn);
 
         CHECK(fn(7) == 42);
         CHECK(fn(8) == 42);
@@ -427,7 +423,7 @@ TEST_CASE("Function with short conditional branch is hooked", "[inline-hook]") {
         CHECK(fn(8) == 1);
         CHECK(fn(9) == 1);
 
-        hook = safetyhook::create_inline(reinterpret_cast<void*>(fn), reinterpret_cast<void*>(Hook::fn));
+        hook = safetyhook::create_inline(fn, Hook::fn);
 
         CHECK(fn(7) == 42);
         CHECK(fn(8) == 43);
@@ -448,7 +444,7 @@ TEST_CASE("Function with short conditional branch is hooked", "[inline-hook]") {
         CHECK(fn(8) == 0);
         CHECK(fn(9) == 1);
 
-        hook = safetyhook::create_inline(reinterpret_cast<void*>(fn), reinterpret_cast<void*>(Hook::fn));
+        hook = safetyhook::create_inline(fn, Hook::fn);
 
         CHECK(fn(7) == 43);
         CHECK(fn(8) == 42);
@@ -469,7 +465,7 @@ TEST_CASE("Function with short conditional branch is hooked", "[inline-hook]") {
         CHECK(fn(8) == 0);
         CHECK(fn(9) == 0);
 
-        hook = safetyhook::create_inline(reinterpret_cast<void*>(fn), reinterpret_cast<void*>(Hook::fn));
+        hook = safetyhook::create_inline(fn, Hook::fn);
 
         CHECK(fn(7) == 42);
         CHECK(fn(8) == 42);
@@ -490,7 +486,7 @@ TEST_CASE("Function with short conditional branch is hooked", "[inline-hook]") {
         CHECK(fn(8) == 1);
         CHECK(fn(9) == 0);
 
-        hook = safetyhook::create_inline(reinterpret_cast<void*>(fn), reinterpret_cast<void*>(Hook::fn));
+        hook = safetyhook::create_inline(fn, Hook::fn);
 
         CHECK(fn(7) == 43);
         CHECK(fn(8) == 43);
@@ -511,7 +507,7 @@ TEST_CASE("Function with short conditional branch is hooked", "[inline-hook]") {
         CHECK(fn(8) == 0);
         CHECK(fn(9) == 0);
 
-        hook = safetyhook::create_inline(reinterpret_cast<void*>(fn), reinterpret_cast<void*>(Hook::fn));
+        hook = safetyhook::create_inline(fn, Hook::fn);
 
         CHECK(fn(7) == 43);
         CHECK(fn(8) == 42);
@@ -532,7 +528,7 @@ TEST_CASE("Function with short conditional branch is hooked", "[inline-hook]") {
         CHECK(fn(8) == 1);
         CHECK(fn(9) == 0);
 
-        hook = safetyhook::create_inline(reinterpret_cast<void*>(fn), reinterpret_cast<void*>(Hook::fn));
+        hook = safetyhook::create_inline(fn, Hook::fn);
 
         CHECK(fn(7) == 42);
         CHECK(fn(8) == 43);
@@ -557,20 +553,18 @@ TEST_CASE("Function with short jump inside trampoline", "[inline-hook]") {
     cg.mov(eax, 42);
     cg.ret();
     cg.nop(10, false);
-    
-    const auto fn = cg.getCode<int(*)()>();
+
+    const auto fn = cg.getCode<int (*)()>();
 
     REQUIRE(fn() == 42);
 
     static SafetyHookInline hook;
 
     struct Hook {
-        static int fn() {
-            return hook.call<int>() + 1;
-        }
+        static int fn() { return hook.call<int>() + 1; }
     };
 
-    hook = safetyhook::create_inline(reinterpret_cast<void*>(fn), reinterpret_cast<void*>(Hook::fn));
+    hook = safetyhook::create_inline(fn, Hook::fn);
 
     REQUIRE(fn() == 43);
 

--- a/unittest/inline_hook.x86_64.cpp
+++ b/unittest/inline_hook.x86_64.cpp
@@ -1,8 +1,8 @@
 #if defined(_M_X64)
 
 #include <catch2/catch_test_macros.hpp>
-#include <xbyak/xbyak.h>
 #include <safetyhook.hpp>
+#include <xbyak/xbyak.h>
 
 void asciiz(Xbyak::CodeGenerator& cg, const char* str) {
     while (*str) {
@@ -19,7 +19,7 @@ TEST_CASE("Function with RIP-relative operand is hooked", "[inline-hook-x86_64]"
     Xbyak::CodeGenerator cg{};
     Xbyak::Label str_label{};
 
-    cg.lea(rax, ptr [rip + str_label]);
+    cg.lea(rax, ptr[rip + str_label]);
     cg.ret();
 
     for (auto i = 0; i < 10; ++i) {
@@ -29,7 +29,7 @@ TEST_CASE("Function with RIP-relative operand is hooked", "[inline-hook-x86_64]"
     cg.L(str_label);
     asciiz(cg, "Hello");
 
-    const auto fn = cg.getCode<const char*(*)()>();
+    const auto fn = cg.getCode<const char* (*)()>();
 
     REQUIRE((fn() == "Hello"sv));
 
@@ -39,7 +39,7 @@ TEST_CASE("Function with RIP-relative operand is hooked", "[inline-hook-x86_64]"
         static const char* fn() { return "Hello, world!"; }
     };
 
-    auto hook_result = SafetyHookInline::create(reinterpret_cast<void*>(fn), reinterpret_cast<void*>(Hook::fn));
+    auto hook_result = SafetyHookInline::create(fn, Hook::fn);
 
     REQUIRE(hook_result);
 
@@ -77,7 +77,7 @@ TEST_CASE("Function with no nearby memory is hooked", "[inline-hook-x86_64]") {
         static int fn(int a) { return hook.call<int>(a) * a; }
     };
 
-    auto hook_result = SafetyHookInline::create(reinterpret_cast<void*>(fn), reinterpret_cast<void*>(Hook::fn));
+    auto hook_result = SafetyHookInline::create(fn, Hook::fn);
 
     REQUIRE(hook_result);
 

--- a/unittest/mid_hook.cpp
+++ b/unittest/mid_hook.cpp
@@ -3,20 +3,18 @@
 
 TEST_CASE("Mid hook to change a register", "[mid_hook]") {
     struct Target {
-        __declspec(noinline) static int __fastcall add_42(int a) {
-            return a + 42;
-        }
+        __declspec(noinline) static int __fastcall add_42(int a) { return a + 42; }
     };
 
     REQUIRE(Target::add_42(0) == 42);
-    
+
     static SafetyHookMid hook;
 
     struct Hook {
         static void add_42(SafetyHookContext& ctx) {
 #if defined(_M_X64)
             ctx.rcx = 1337 - 42;
-#elif defined(_M_IX86) 
+#elif defined(_M_IX86)
             ctx.ecx = 1337 - 42;
 #else
 #error "Unsupported architecture"
@@ -24,7 +22,7 @@ TEST_CASE("Mid hook to change a register", "[mid_hook]") {
         }
     };
 
-    auto hook_result = SafetyHookMid::create(reinterpret_cast<void*>(Target::add_42), Hook::add_42);
+    auto hook_result = SafetyHookMid::create(Target::add_42, Hook::add_42);
 
     REQUIRE(hook_result);
 


### PR DESCRIPTION
This fixes instances where unsigned integer overflow could occur when calculating new displacements and uint8_t*'s are generally just easier to work with.