### PR TITLE
Removal of the Windows.h include from thread_freezer.hpp

### DIFF
--- a/include/safetyhook/thread_freezer.hpp
+++ b/include/safetyhook/thread_freezer.hpp
@@ -6,7 +6,9 @@
 #include <cstdint>
 #include <functional>
 
-#include <Windows.h>
+using HANDLE = void*;
+struct _CONTEXT;
+using CONTEXT = _CONTEXT;
 
 namespace safetyhook {
 /// @brief Executes a function while all other threads are frozen. Also allows for visiting each frozen thread and


### PR DESCRIPTION
This PR should stop Windows.h from leaking into users of this library.