### PR TITLE
Fix/Remove `Windows.h` from `thread_freezer.hpp`

### DIFF
--- a/include/safetyhook/thread_freezer.hpp
+++ b/include/safetyhook/thread_freezer.hpp
@@ -6,9 +6,9 @@
 #include <cstdint>
 #include <functional>
 
-#include <Windows.h>
-
 namespace safetyhook {
+using FixIpFn = std::function<void(uint8_t* old_ip, uint8_t* new_ip)>;
+
 /// @brief Executes a function while all other threads are frozen. Also allows for visiting each frozen thread and
 /// modifying it's context.
 /// @param run_fn The function to run while all other threads are frozen.
@@ -17,11 +17,5 @@ namespace safetyhook {
 /// @note The visit function will be called before the run function.
 /// @note Keep the logic inside run_fn and visit_fn as simple as possible to avoid deadlocks.
 void execute_while_frozen(
-    const std::function<void()>& run_fn, const std::function<void(uint32_t, HANDLE, CONTEXT&)>& visit_fn = {});
-
-/// @brief Will modify the context of a thread's IP to point to a new address if its IP is at the old address.
-/// @param ctx The thread context to modify.
-/// @param old_ip The old IP address.
-/// @param new_ip The new IP address.
-void fix_ip(CONTEXT& ctx, uint8_t* old_ip, uint8_t* new_ip);
+    const std::function<void()>& run_fn, const std::function<void(uint32_t, const FixIpFn&)>& visit_fn = {});
 } // namespace safetyhook

--- a/src/inline_hook.cpp
+++ b/src/inline_hook.cpp
@@ -318,9 +318,9 @@ std::expected<void, InlineHook::Error> InlineHook::e9_hook(const std::shared_ptr
             const auto dst = reinterpret_cast<uint8_t*>(&trampoline_epilogue->jmp_to_destination);
             emit_jmp_e9(src, dst, m_original_bytes.size());
         },
-        [this](uint32_t, HANDLE, CONTEXT& ctx) {
+        [this](uint32_t, auto& fix_ip) {
             for (size_t i = 0; i < m_original_bytes.size(); ++i) {
-                fix_ip(ctx, m_target + i, m_trampoline.data() + i);
+                fix_ip(m_target + i, m_trampoline.data() + i);
             }
         });
 
@@ -376,9 +376,9 @@ std::expected<void, InlineHook::Error> InlineHook::ff_hook(const std::shared_ptr
             const auto data = src + sizeof(JmpFF);
             emit_jmp_ff(src, dst, data, m_original_bytes.size());
         },
-        [this](uint32_t, HANDLE, CONTEXT& ctx) {
+        [this](uint32_t, auto& fix_ip) {
             for (size_t i = 0; i < m_original_bytes.size(); ++i) {
-                fix_ip(ctx, m_target + i, m_trampoline.data() + i);
+                fix_ip(m_target + i, m_trampoline.data() + i);
             }
         });
 
@@ -398,9 +398,9 @@ void InlineHook::destroy() {
             UnprotectMemory unprotect{m_target, m_original_bytes.size()};
             std::copy(m_original_bytes.begin(), m_original_bytes.end(), m_target);
         },
-        [this](uint32_t, HANDLE, CONTEXT& ctx) {
+        [this](uint32_t, auto& fix_ip) {
             for (size_t i = 0; i < m_original_bytes.size(); ++i) {
-                fix_ip(ctx, m_trampoline.data() + i, m_target + i);
+                fix_ip(m_trampoline.data() + i, m_target + i);
             }
         });
 


### PR DESCRIPTION
Refactors `thread_freezer.hpp` to remove the need to include `Windows.h`.