### PR TITLE
Use lowercase windows.h for building on Linux with MinGW

### DIFF
--- a/include/safetyhook/thread_freezer.hpp
+++ b/include/safetyhook/thread_freezer.hpp
@@ -6,7 +6,13 @@
 #include <cstdint>
 #include <functional>
 
+#if __has_include(<Windows.h>)
 #include <Windows.h>
+#elif __has_include(<windows.h>)
+#include <windows.h>
+#else
+#error "Windows.h not found"
+#endif
 
 namespace safetyhook {
 /// @brief Executes a function while all other threads are frozen. Also allows for visiting each frozen thread and

--- a/src/allocator.cpp
+++ b/src/allocator.cpp
@@ -3,7 +3,13 @@
 #include <limits>
 
 #define NOMINMAX
+#if __has_include(<Windows.h>)
 #include <Windows.h>
+#elif __has_include(<windows.h>)
+#include <windows.h>
+#else
+#error "Windows.h not found"
+#endif
 
 #include <safetyhook/allocator.hpp>
 

--- a/src/inline_hook.cpp
+++ b/src/inline_hook.cpp
@@ -1,6 +1,12 @@
 #include <iterator>
 
+#if __has_include(<Windows.h>)
 #include <Windows.h>
+#elif __has_include(<windows.h>)
+#include <windows.h>
+#else
+#error "Windows.h not found"
+#endif
 
 #if __has_include(<Zydis/Zydis.h>)
 #include <Zydis/Zydis.h>

--- a/src/thread_freezer.cpp
+++ b/src/thread_freezer.cpp
@@ -1,4 +1,10 @@
+#if __has_include(<Windows.h>)
 #include <Windows.h>
+#elif __has_include(<windows.h>)
+#include <windows.h>
+#else
+#error "Windows.h not found"
+#endif
 #include <winternl.h>
 
 #include <safetyhook/thread_freezer.hpp>

--- a/src/utility.cpp
+++ b/src/utility.cpp
@@ -1,4 +1,10 @@
+#if __has_include(<Windows.h>)
 #include <Windows.h>
+#elif __has_include(<windows.h>)
+#include <windows.h>
+#else
+#error "Windows.h not found"
+#endif
 
 #include <safetyhook/utility.hpp>
 

--- a/src/vmt_hook.cpp
+++ b/src/vmt_hook.cpp
@@ -1,4 +1,10 @@
+#if __has_include(<Windows.h>)
 #include <Windows.h>
+#elif __has_include(<windows.h>)
+#include <windows.h>
+#else
+#error "Windows.h not found"
+#endif
 
 #include <safetyhook/thread_freezer.hpp>
 

--- a/tests/test4.cpp
+++ b/tests/test4.cpp
@@ -1,4 +1,10 @@
+#if __has_include(<Windows.h>)
 #include <Windows.h>
+#elif __has_include(<windows.h>)
+#include <windows.h>
+#else
+#error "Windows.h not found"
+#endif
 
 #include <safetyhook.hpp>
 


### PR DESCRIPTION
A few very minor changes to make life a bit easier for anyone cross-compiling under Linux.

Here's a minimal example to confirm the build error with Docker:

```bash
docker run --rm -it archlinux:base-devel /bin/bash
pacman --sync --refresh --noconfirm --needed git ninja cmake mingw-w64 python
git clone https://github.com/cursey/safetyhook.git
cmake -S safetyhook/ -G Ninja -B safetyhook_build/ \
  -DCMAKE_SYSTEM_NAME=Windows \
  -DCMAKE_SYSTEM_PROCESSOR=x86_64 \
  -DCMAKE_C_COMPILER=/usr/bin/x86_64-w64-mingw32-gcc \
  -DCMAKE_CXX_COMPILER=/usr/bin/x86_64-w64-mingw32-g++ \
  -DCMAKE_FIND_ROOT_PATH=/usr/x86_64-w64-mingw32 \
  -DCMAKE_BUILD_TYPE=Release \
  -DSAFETYHOOK_FETCH_ZYDIS=ON \
  -DSAFETYHOOK_BUILD_TESTS=OFF \
  -DSAFETYHOOK_AMALGAMATE=ON
cmake --build safetyhook_build/
```

The PR changes can be tested by running these additional two commands:

```
cd safetyhook
curl https://patch-diff.githubusercontent.com/raw/cursey/safetyhook/pull/44.patch | git apply
cmake --build ../safetyhook_build/
```

I ran into some other errors with xbyak when building with tests, so these changes will only cover building the library itself.