### PR TITLE
Fix deadlock with Windows Loader during execute_while_frozen

### DIFF
--- a/src/thread_freezer.cpp
+++ b/src/thread_freezer.cpp
@@ -36,7 +36,7 @@ void execute_while_frozen(
     auto unlock_loader = (PFN_LdrUnlockLoaderLock)GetProcAddress(ntdll, "LdrUnlockLoaderLock");
 
     if (lock_loader != nullptr && unlock_loader != nullptr) {
-        lock_loader(0, NULL, &loader_magic);
+        lock_loader(0, nullptr, &loader_magic);
     }
 
     do {
@@ -97,7 +97,7 @@ void execute_while_frozen(
                 // Lock it again.
                 if (lock_loader != nullptr && unlock_loader != nullptr) {
                     loader_magic = 0;
-                    lock_loader(0, NULL, &loader_magic);
+                    lock_loader(0, nullptr, &loader_magic);
                 }
             }
 

--- a/src/thread_freezer.cpp
+++ b/src/thread_freezer.cpp
@@ -87,7 +87,18 @@ void execute_while_frozen(
             }
 
             if (visit_fn) {
+                // Unlock the loader lock.
+                if (lock_loader != nullptr && unlock_loader != nullptr) {
+                    unlock_loader(0, loader_magic);
+                }
+
                 visit_fn(thread_id, thread, thread_ctx);
+
+                // Lock it again.
+                if (lock_loader != nullptr && unlock_loader != nullptr) {
+                    loader_magic = 0;
+                    lock_loader(0, NULL, &loader_magic);
+                }
             }
 
             ++num_threads_frozen;


### PR DESCRIPTION
I noticed a freeze when calling safetyhook::create_inline, and I assume this is where the problem came from. Either that or it was one of my many calls to execute_while_frozen.