### PR TITLE
Add support for consumption by projects that use C++ modules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,7 @@ option(SAFETYHOOK_BUILD_TEST "" OFF)
 option(SAFETYHOOK_BUILD_EXAMPLES "" OFF)
 option(SAFETYHOOK_AMALGAMATE "" OFF)
 option(SAFETYHOOK_FETCH_ZYDIS "" OFF)
+option(SAFETYHOOK_USE_CXXMODULES "" OFF)
 
 project(safetyhook)
 
@@ -145,6 +146,11 @@ target_include_directories(safetyhook PUBLIC
 target_link_libraries(safetyhook PUBLIC
 	Zydis
 )
+
+set(CMKR_TARGET safetyhook)
+if(SAFETYHOOK_USE_CXXMODULES)
+    target_compile_definitions(safetyhook INTERFACE SAFETYHOOK_USE_CXXMODULES)
+endif()
 
 # Target: docs
 if(SAFETYHOOK_BUILD_DOCS) # build-docs

--- a/cmake.toml
+++ b/cmake.toml
@@ -8,6 +8,7 @@ SAFETYHOOK_BUILD_TEST = false
 SAFETYHOOK_BUILD_EXAMPLES = false
 SAFETYHOOK_AMALGAMATE = false
 SAFETYHOOK_FETCH_ZYDIS = false
+SAFETYHOOK_USE_CXXMODULES = false
 
 [conditions]
 build-docs = "SAFETYHOOK_BUILD_DOCS"
@@ -59,6 +60,11 @@ link-libraries = ["Zydis"]
 msvc.private-compile-options = ["/permissive-", "/W4", "/w14640"]
 clang.private-compile-options = ["-Wall", "-Wextra", "-Wshadow", "-Wnon-virtual-dtor", "-pedantic"]
 gcc.private-compile-options = ["-Wall", "-Wextra", "-Wshadow", "-Wnon-virtual-dtor", "-pedantic"]
+cmake-after = """
+if(SAFETYHOOK_USE_CXXMODULES)
+    target_compile_definitions(safetyhook INTERFACE SAFETYHOOK_USE_CXXMODULES)
+endif()
+"""
 
 [target.docs]
 condition = "build-docs"

--- a/include/safetyhook/allocator.hpp
+++ b/include/safetyhook/allocator.hpp
@@ -3,11 +3,15 @@
 
 #pragma once
 
+#ifndef SAFETYHOOK_USE_CXXMODULES
 #include <cstdint>
 #include <expected>
 #include <memory>
 #include <mutex>
 #include <vector>
+#elif 
+import std.compat;
+#endif
 
 namespace safetyhook {
 class Allocator;

--- a/include/safetyhook/allocator.hpp
+++ b/include/safetyhook/allocator.hpp
@@ -9,7 +9,7 @@
 #include <memory>
 #include <mutex>
 #include <vector>
-#elif 
+#else
 import std.compat;
 #endif
 

--- a/include/safetyhook/context.hpp
+++ b/include/safetyhook/context.hpp
@@ -3,7 +3,11 @@
 
 #pragma once
 
+#ifndef SAFETYHOOK_USE_CXXMODULES
 #include <cstdint>
+#elif
+import std.compat;
+#endif
 
 #include "safetyhook/common.hpp"
 

--- a/include/safetyhook/context.hpp
+++ b/include/safetyhook/context.hpp
@@ -5,7 +5,7 @@
 
 #ifndef SAFETYHOOK_USE_CXXMODULES
 #include <cstdint>
-#elif
+#else
 import std.compat;
 #endif
 

--- a/include/safetyhook/inline_hook.hpp
+++ b/include/safetyhook/inline_hook.hpp
@@ -10,7 +10,7 @@
 #include <mutex>
 #include <utility>
 #include <vector>
-#elif 
+#else
 import std.compat;
 #endif
 

--- a/include/safetyhook/inline_hook.hpp
+++ b/include/safetyhook/inline_hook.hpp
@@ -3,12 +3,16 @@
 
 #pragma once
 
+#ifndef SAFETYHOOK_USE_CXXMODULES
 #include <cstdint>
 #include <expected>
 #include <memory>
 #include <mutex>
 #include <utility>
 #include <vector>
+#elif 
+import std.compat;
+#endif
 
 #include "safetyhook/allocator.hpp"
 #include "safetyhook/common.hpp"

--- a/include/safetyhook/mid_hook.hpp
+++ b/include/safetyhook/mid_hook.hpp
@@ -6,7 +6,7 @@
 #ifndef SAFETYHOOK_USE_CXXMODULES
 #include <cstdint>
 #include <memory>
-#elif 
+#else
 import std.compat;
 #endif
 

--- a/include/safetyhook/mid_hook.hpp
+++ b/include/safetyhook/mid_hook.hpp
@@ -3,8 +3,12 @@
 
 #pragma once
 
+#ifndef SAFETYHOOK_USE_CXXMODULES
 #include <cstdint>
 #include <memory>
+#elif 
+import std.compat;
+#endif
 
 #include "safetyhook/allocator.hpp"
 #include "safetyhook/context.hpp"

--- a/include/safetyhook/os.hpp
+++ b/include/safetyhook/os.hpp
@@ -5,7 +5,7 @@
 #include <cstdint>
 #include <expected>
 #include <functional>
-#elif
+#else
 import std.compat;
 #endif
 

--- a/include/safetyhook/os.hpp
+++ b/include/safetyhook/os.hpp
@@ -1,9 +1,13 @@
 // This is the OS abstraction layer.
 #pragma once
 
+#ifndef SAFETYHOOK_USE_CXXMODULES
 #include <cstdint>
 #include <expected>
 #include <functional>
+#elif
+import std.compat;
+#endif
 
 namespace safetyhook {
 

--- a/include/safetyhook/utility.hpp
+++ b/include/safetyhook/utility.hpp
@@ -1,9 +1,13 @@
 #pragma once
 
+#ifndef SAFETYHOOK_USE_CXXMODULES
 #include <algorithm>
 #include <cstdint>
 #include <optional>
 #include <type_traits>
+#elif 
+import std.compat;
+#endif
 
 namespace safetyhook {
 template <typename T> constexpr void store(uint8_t* address, const T& value) {

--- a/include/safetyhook/utility.hpp
+++ b/include/safetyhook/utility.hpp
@@ -5,7 +5,7 @@
 #include <cstdint>
 #include <optional>
 #include <type_traits>
-#elif 
+#else
 import std.compat;
 #endif
 

--- a/include/safetyhook/vmt_hook.hpp
+++ b/include/safetyhook/vmt_hook.hpp
@@ -7,7 +7,7 @@
 #include <cstdint>
 #include <expected>
 #include <unordered_map>
-#elif
+#else
 import std.compat;
 #endif
 

--- a/include/safetyhook/vmt_hook.hpp
+++ b/include/safetyhook/vmt_hook.hpp
@@ -3,9 +3,13 @@
 
 #pragma once
 
+#ifndef SAFETYHOOK_USE_CXXMODULES
 #include <cstdint>
 #include <expected>
 #include <unordered_map>
+#elif
+import std.compat;
+#endif
 
 #include "safetyhook/allocator.hpp"
 #include "safetyhook/common.hpp"


### PR DESCRIPTION
Adds a preprocessor define `SAFETYHOOK_USE_CXXMODULES` to public-facing headers that allows for the standard library to be included by-module instead of by-header to prevent issues in projects using C++ modules.