### PR TITLE
Fix/Add missing SetThreadContext

### DIFF
--- a/src/os.windows.cpp
+++ b/src/os.windows.cpp
@@ -216,6 +216,8 @@ void execute_while_frozen(
                     static_cast<ThreadContext>(&thread_ctx));
             }
 
+            SetThreadContext(thread, &thread_ctx);
+
             ++num_threads_frozen;
         }
 


### PR DESCRIPTION
This PR addresses the issue where the thread freezer system (on Windows) could modify a threads IP but that change is never realized because `SetThreadContext` was never called.

Closes #66 