### PR TITLE
Use _WIN32 define instead of WIN32

### DIFF
--- a/include/safetyhook/common.hpp
+++ b/include/safetyhook/common.hpp
@@ -38,7 +38,7 @@
 #endif
 #endif
 
-#if defined(WIN32)
+#if defined(_WIN32)
 #define SAFETYHOOK_OS_WINDOWS 1
 #define SAFETYHOOK_OS_LINUX 0
 #elif defined(__linux__)


### PR DESCRIPTION
`_WIN32` is more reliable as it is defined by the compiler instead of Windows.h. Under two different build environments, I encountered an issue where `WIN32` wasn't defined which resulted in a compiler error.