### PR TITLE
Align trampoline to nearest 16 bytes to prevent crash

### DIFF
--- a/src/allocator.cpp
+++ b/src/allocator.cpp
@@ -84,6 +84,7 @@ void Allocator::free(uint8_t* address, size_t size) {
 
 std::expected<Allocation, Allocator::Error> Allocator::internal_allocate_near(
     const std::vector<uint8_t*>& desired_addresses, size_t size, size_t max_distance) {
+    size = align_up(size, 16); // align to nearest 16 bytes or crash!
     // First search through our list of allocations for a free block that is large
     // enough.
     for (const auto& allocation : m_memory) {


### PR DESCRIPTION
Not having the trampoline aligned by 16 bytes seems to cause random crashes/memory corruption on 32bit. I did not run into any weird issues like this on 64bits with a bunch of hooks strangely.

I was trying to figure out why it was crashing and after staring at the assembly for an entire day, I finally thought about alignment. The 2 hooks I was having problems with had trampoline sizes of 15 bytes.