### PR TITLE
Remove `FnPtr` and use templates instead

### DIFF
--- a/format.ps1
+++ b/format.ps1
@@ -1,4 +1,4 @@
-Get-ChildItem -Path .\src, .\include, .\tests, .\unittest -Include *.hpp, *.cpp -Recurse |
+Get-ChildItem -Path .\src, .\include, .\test, .\example -Include *.hpp, *.cpp -Recurse |
 ForEach-Object {
     Write-Output $_.FullName
     &clang-format -i -style=file $_.FullName

--- a/include/safetyhook/easy.hpp
+++ b/include/safetyhook/easy.hpp
@@ -21,8 +21,8 @@ namespace safetyhook {
 /// @param destination The address of the destination function.
 /// @param flags The flags to use.
 /// @return The InlineHook object.
-[[nodiscard]] InlineHook create_inline(
-    FnPtr auto target, FnPtr auto destination, InlineHook::Flags flags = InlineHook::Default) {
+template <typename T>
+[[nodiscard]] InlineHook create_inline(T target, T destination, InlineHook::Flags flags = InlineHook::Default) {
     return create_inline(reinterpret_cast<void*>(target), reinterpret_cast<void*>(destination), flags);
 }
 
@@ -38,7 +38,8 @@ namespace safetyhook {
 /// @param destination The destination function.
 /// @param flags The flags to use.
 /// @return The MidHook object.
-[[nodiscard]] MidHook create_mid(FnPtr auto target, MidHookFn destination, MidHook::Flags flags = MidHook::Default) {
+template <typename T>
+[[nodiscard]] MidHook create_mid(T target, MidHookFn destination, MidHook::Flags flags = MidHook::Default) {
     return create_mid(reinterpret_cast<void*>(target), destination, flags);
 }
 
@@ -52,7 +53,7 @@ namespace safetyhook {
 /// @param index The index of the method to hook.
 /// @param destination The destination function.
 /// @return The VmHook object.
-[[nodiscard]] VmHook create_vm(VmtHook& vmt, size_t index, FnPtr auto destination) {
+template <typename T> [[nodiscard]] VmHook create_vm(VmtHook& vmt, size_t index, T destination) {
     if (auto hook = vmt.hook_method(index, destination)) {
         return std::move(*hook);
     } else {

--- a/include/safetyhook/inline_hook.hpp
+++ b/include/safetyhook/inline_hook.hpp
@@ -110,8 +110,8 @@ public:
     /// @return The InlineHook or an InlineHook::Error if an error occurred.
     /// @note This will use the default global Allocator.
     /// @note If you don't care about error handling, use the easy API (safetyhook::create_inline).
-    [[nodiscard]] static std::expected<InlineHook, Error> create(
-        FnPtr auto target, FnPtr auto destination, Flags flags = Default) {
+    template <typename T>
+    [[nodiscard]] static std::expected<InlineHook, Error> create(T target, T destination, Flags flags = Default) {
         return create(reinterpret_cast<void*>(target), reinterpret_cast<void*>(destination), flags);
     }
 
@@ -132,8 +132,9 @@ public:
     /// @param flags The flags to use.
     /// @return The InlineHook or an InlineHook::Error if an error occurred.
     /// @note If you don't care about error handling, use the easy API (safetyhook::create_inline).
+    template <typename T>
     [[nodiscard]] static std::expected<InlineHook, Error> create(
-        const std::shared_ptr<Allocator>& allocator, FnPtr auto target, FnPtr auto destination, Flags flags = Default) {
+        const std::shared_ptr<Allocator>& allocator, T target, T destination, Flags flags = Default) {
         return create(allocator, reinterpret_cast<void*>(target), reinterpret_cast<void*>(destination), flags);
     }
 

--- a/include/safetyhook/mid_hook.hpp
+++ b/include/safetyhook/mid_hook.hpp
@@ -75,8 +75,9 @@ public:
     /// @return The MidHook object or a MidHook::Error if an error occurred.
     /// @note This will use the default global Allocator.
     /// @note If you don't care about error handling, use the easy API (safetyhook::create_mid).
+    template <typename T>
     [[nodiscard]] static std::expected<MidHook, Error> create(
-        FnPtr auto target, MidHookFn destination_fn, Flags flags = Default) {
+        T target, MidHookFn destination_fn, Flags flags = Default) {
         return create(reinterpret_cast<void*>(target), destination_fn, flags);
     }
 
@@ -98,8 +99,9 @@ public:
     /// @param flags The flags to use.
     /// @return The MidHook object or a MidHook::Error if an error occurred.
     /// @note If you don't care about error handling, use the easy API (safetyhook::create_mid).
-    [[nodiscard]] static std::expected<MidHook, Error> create(const std::shared_ptr<Allocator>& allocator,
-        FnPtr auto target, MidHookFn destination_fn, Flags flags = Default) {
+    template <typename T>
+    [[nodiscard]] static std::expected<MidHook, Error> create(
+        const std::shared_ptr<Allocator>& allocator, T target, MidHookFn destination_fn, Flags flags = Default) {
         return create(allocator, reinterpret_cast<void*>(target), destination_fn, flags);
     }
 

--- a/include/safetyhook/utility.hpp
+++ b/include/safetyhook/utility.hpp
@@ -14,16 +14,13 @@ template <typename T> constexpr void store(uint8_t* address, const T& value) {
     std::copy_n(reinterpret_cast<const uint8_t*>(&value), sizeof(T), address);
 }
 
-template <typename T> constexpr T address_cast(auto address) {
+template <typename T, typename U> constexpr T address_cast(U address) {
     if constexpr (std::is_integral_v<T> && std::is_integral_v<decltype(address)>) {
         return static_cast<T>(address);
     } else {
         return reinterpret_cast<T>(address);
     }
 }
-
-template <typename T>
-concept FnPtr = requires(T f) { std::is_pointer_v<T>&& std::is_function_v<std::remove_pointer_t<T>>; };
 
 bool is_executable(uint8_t* address);
 

--- a/include/safetyhook/utility.hpp
+++ b/include/safetyhook/utility.hpp
@@ -15,7 +15,7 @@ template <typename T> constexpr void store(uint8_t* address, const T& value) {
 }
 
 template <typename T, typename U> constexpr T address_cast(U address) {
-    if constexpr (std::is_integral_v<T> && std::is_integral_v<decltype(address)>) {
+    if constexpr (std::is_integral_v<T> && std::is_integral_v<U>) {
         return static_cast<T>(address);
     } else {
         return reinterpret_cast<T>(address);

--- a/include/safetyhook/vmt_hook.hpp
+++ b/include/safetyhook/vmt_hook.hpp
@@ -141,7 +141,7 @@ public:
     /// @brief Hooks a method in the VMT.
     /// @param index The index of the method to hook.
     /// @param new_function The new function to use.
-    [[nodiscard]] std::expected<VmHook, Error> hook_method(size_t index, FnPtr auto new_function) {
+    template <typename T> [[nodiscard]] std::expected<VmHook, Error> hook_method(size_t index, T new_function) {
         VmHook hook{};
 
         ++index; // Skip RTTI pointer.

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -1,3 +1,4 @@
 #include <boost/ut.hpp>
 
-int main() {}
+int main() {
+}


### PR DESCRIPTION
* Minor changes to `address_cast`.
* Remove `FnPtr` and use templates instead.
* Fix `format.ps1` (some directories were named incorrectly).

There's no more type constraints and hook arguments just get cast to `void*` now.