### PR TITLE
Fix LoadLibraryExW hooking crash

### DIFF
--- a/src/os.windows.cpp
+++ b/src/os.windows.cpp
@@ -271,10 +271,12 @@ void trap_threads(uint8_t* from, uint8_t* to, size_t len, const std::function<vo
     }
 
     auto si = system_info();
-
-    // Check if the target shares a memory page with VirtualProtect
-    if (reinterpret_cast<uint8_t*>(&VirtualProtect) <= align_up(from + len, si.page_size) &&
-        align_down(from, si.page_size) <= reinterpret_cast<uint8_t*>(&VirtualProtect) + 0x20) {
+    auto *from_page_start = align_down(from, si.page_size);
+    auto *from_page_end = align_up(from + len, si.page_size);
+    auto *vp_start = reinterpret_cast<uint8_t*>(&VirtualProtect);
+    auto *vp_end = vp_start + 0x20;
+    
+    if (!(from_page_end < vp_start || vp_end < from_page_start)){
         new_protect = PAGE_EXECUTE_READWRITE;
     }
 

--- a/src/os.windows.cpp
+++ b/src/os.windows.cpp
@@ -272,8 +272,8 @@ void trap_threads(uint8_t* from, uint8_t* to, size_t len, const std::function<vo
         new_protect = PAGE_EXECUTE_READWRITE;
     }
 
-    if (from_mbi.AllocationBase == virtual_protect_mbi.AllocationBase ||
-        to_mbi.AllocationBase == virtual_protect_mbi.AllocationBase) {
+    if (from_mbi.BaseAddress == virtual_protect_mbi.BaseAddress ||
+        to_mbi.BaseAddress == virtual_protect_mbi.BaseAddress) {
         new_protect = PAGE_EXECUTE_READWRITE;
     }
 

--- a/src/os.windows.cpp
+++ b/src/os.windows.cpp
@@ -259,14 +259,21 @@ void trap_threads(uint8_t* from, uint8_t* to, size_t len, const std::function<vo
     MEMORY_BASIC_INFORMATION find_me_mbi{};
     MEMORY_BASIC_INFORMATION from_mbi{};
     MEMORY_BASIC_INFORMATION to_mbi{};
+    MEMORY_BASIC_INFORMATION virtual_protect_mbi{};
 
     VirtualQuery(reinterpret_cast<void*>(find_me), &find_me_mbi, sizeof(find_me_mbi));
     VirtualQuery(from, &from_mbi, sizeof(from_mbi));
     VirtualQuery(to, &to_mbi, sizeof(to_mbi));
+    VirtualQuery(reinterpret_cast<void*>(VirtualProtect), &virtual_protect_mbi, sizeof(virtual_protect_mbi));
 
     auto new_protect = PAGE_READWRITE;
 
     if (from_mbi.AllocationBase == find_me_mbi.AllocationBase || to_mbi.AllocationBase == find_me_mbi.AllocationBase) {
+        new_protect = PAGE_EXECUTE_READWRITE;
+    }
+
+    if (from_mbi.AllocationBase == virtual_protect_mbi.AllocationBase ||
+        to_mbi.AllocationBase == virtual_protect_mbi.AllocationBase) {
         new_protect = PAGE_EXECUTE_READWRITE;
     }
 


### PR DESCRIPTION
Closes [#70](https://github.com/cursey/safetyhook/issues/70). Adds check if from/to address is on same page as VirtualProtect, if so use PAGE_EXECUTE_READWRITE (ie no trapping) instead.