### PR TITLE
Add CMake installation rules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,8 @@ if(SAFETYHOOK_BUILD_TEST) # build-test
 			v2.0.1
 		GIT_SHALLOW
 			ON
+		EXCLUDE_FROM_ALL
+			ON
 	)
 	FetchContent_MakeAvailable(ut)
 
@@ -57,6 +59,8 @@ if(SAFETYHOOK_BUILD_TEST) # build-test
 		GIT_TAG
 			v6.69
 		GIT_SHALLOW
+			ON
+		EXCLUDE_FROM_ALL
 			ON
 	)
 	FetchContent_MakeAvailable(xbyak)
@@ -74,6 +78,8 @@ if(SAFETYHOOK_FETCH_ZYDIS) # fetch-zydis
 		GIT_TAG
 			v4.1.0
 		GIT_SHALLOW
+			ON
+		EXCLUDE_FROM_ALL
 			ON
 	)
 	FetchContent_MakeAvailable(Zydis)
@@ -159,7 +165,8 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_C_COMPILER_ID STREQUAL "GNU") #
 endif()
 
 target_include_directories(safetyhook PUBLIC
-	"include/"
+	"$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+	"$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>"
 )
 
 target_link_libraries(safetyhook PUBLIC
@@ -170,6 +177,29 @@ set(CMKR_TARGET safetyhook)
 if(SAFETYHOOK_USE_CXXMODULES)
     target_compile_definitions(safetyhook INTERFACE SAFETYHOOK_USE_CXXMODULES)
 endif()
+
+include(GNUInstallDirs)
+
+install(
+    TARGETS safetyhook
+    EXPORT safetyhook-export
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+)
+
+install(
+    DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+)
+
+install(
+    EXPORT safetyhook-export
+    FILE safetyhook-config.cmake
+    NAMESPACE safetyhook::
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/safetyhook
+)
 
 # Target: docs
 if(SAFETYHOOK_BUILD_DOCS) # build-docs

--- a/cmake.toml
+++ b/cmake.toml
@@ -26,12 +26,14 @@ condition = "build-test"
 git = "https://github.com/boost-ext/ut.git"
 tag = "v2.0.1"
 shallow = true
+EXCLUDE_FROM_ALL = true
 
 [fetch-content.xbyak]
 condition = "build-test"
 git = "https://github.com/herumi/xbyak.git"
 tag = "v6.69"
 shallow = true
+EXCLUDE_FROM_ALL = true
 
 [fetch-content.Zydis]
 condition = "fetch-zydis"
@@ -46,6 +48,7 @@ option(ZYDIS_BUILD_DOXYGEN "" OFF)
 cmake-after = """
 add_library(Zydis::Zydis ALIAS Zydis)
 """
+EXCLUDE_FROM_ALL = true
 
 [find-package.Doxygen]
 condition = "build-docs"
@@ -63,7 +66,10 @@ required = true
 [target.safetyhook]
 type = "library"
 sources = ["src/*.cpp"]
-include-directories = ["include/"]
+include-directories = [
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>",
+    "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>"
+]
 compile-features = ["cxx_std_23"]
 alias = "safetyhook::safetyhook"
 link-libraries = ["Zydis::Zydis"]
@@ -76,6 +82,29 @@ cmake-after = """
 if(SAFETYHOOK_USE_CXXMODULES)
     target_compile_definitions(safetyhook INTERFACE SAFETYHOOK_USE_CXXMODULES)
 endif()
+
+include(GNUInstallDirs)
+
+install(
+    TARGETS safetyhook
+    EXPORT safetyhook-export
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+)
+
+install(
+    DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+)
+
+install(
+    EXPORT safetyhook-export
+    FILE safetyhook-config.cmake
+    NAMESPACE safetyhook::
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/safetyhook
+)
 """
 
 [target.docs]


### PR DESCRIPTION
Follow-up from #69, here are a few minor CMake changes to ensure things are installed to the usual places.

I'm hoping to contribute packages to vcpkg & MSYS2 afterwards.

> `-DBUILD_SHARED_LIBS=OFF`
```
-- Install configuration: "Debug"
-- Installing: Z:/safetyhook/cmake-build-debug-static/install/lib/libsafetyhook.a
-- Installing: Z:/safetyhook/cmake-build-debug-static/install/include
-- Installing: Z:/safetyhook/cmake-build-debug-static/install/include/safetyhook
-- Installing: Z:/safetyhook/cmake-build-debug-static/install/include/safetyhook/allocator.hpp
-- Installing: Z:/safetyhook/cmake-build-debug-static/install/include/safetyhook/common.hpp
-- Installing: Z:/safetyhook/cmake-build-debug-static/install/include/safetyhook/context.hpp
-- Installing: Z:/safetyhook/cmake-build-debug-static/install/include/safetyhook/easy.hpp
-- Installing: Z:/safetyhook/cmake-build-debug-static/install/include/safetyhook/inline_hook.hpp
-- Installing: Z:/safetyhook/cmake-build-debug-static/install/include/safetyhook/mid_hook.hpp
-- Installing: Z:/safetyhook/cmake-build-debug-static/install/include/safetyhook/os.hpp
-- Installing: Z:/safetyhook/cmake-build-debug-static/install/include/safetyhook/utility.hpp
-- Installing: Z:/safetyhook/cmake-build-debug-static/install/include/safetyhook/vmt_hook.hpp
-- Installing: Z:/safetyhook/cmake-build-debug-static/install/include/safetyhook.hpp
-- Installing: Z:/safetyhook/cmake-build-debug-static/install/lib/cmake/safetyhook/safetyhook-config.cmake
-- Installing: Z:/safetyhook/cmake-build-debug-static/install/lib/cmake/safetyhook/safetyhook-config-debug.cmake
```

> `-DBUILD_SHARED_LIBS=ON`
```
-- Install configuration: "Debug"
-- Installing: Z:/safetyhook/cmake-build-debug-shared/install/lib/libsafetyhook.dll.a
-- Installing: Z:/safetyhook/cmake-build-debug-shared/install/bin/libsafetyhook.dll
-- Installing: Z:/safetyhook/cmake-build-debug-shared/install/include
-- Installing: Z:/safetyhook/cmake-build-debug-shared/install/include/safetyhook
-- Installing: Z:/safetyhook/cmake-build-debug-shared/install/include/safetyhook/allocator.hpp
-- Installing: Z:/safetyhook/cmake-build-debug-shared/install/include/safetyhook/common.hpp
-- Installing: Z:/safetyhook/cmake-build-debug-shared/install/include/safetyhook/context.hpp
-- Installing: Z:/safetyhook/cmake-build-debug-shared/install/include/safetyhook/easy.hpp
-- Installing: Z:/safetyhook/cmake-build-debug-shared/install/include/safetyhook/inline_hook.hpp
-- Installing: Z:/safetyhook/cmake-build-debug-shared/install/include/safetyhook/mid_hook.hpp
-- Installing: Z:/safetyhook/cmake-build-debug-shared/install/include/safetyhook/os.hpp
-- Installing: Z:/safetyhook/cmake-build-debug-shared/install/include/safetyhook/utility.hpp
-- Installing: Z:/safetyhook/cmake-build-debug-shared/install/include/safetyhook/vmt_hook.hpp
-- Installing: Z:/safetyhook/cmake-build-debug-shared/install/include/safetyhook.hpp
-- Installing: Z:/safetyhook/cmake-build-debug-shared/install/lib/cmake/safetyhook/safetyhook-config.cmake
-- Installing: Z:/safetyhook/cmake-build-debug-shared/install/lib/cmake/safetyhook/safetyhook-config-debug.cmake
```