### PR TITLE
Make sure `os.hpp` is included for amalgamate.

### DIFF
--- a/amalgamate.py
+++ b/amalgamate.py
@@ -15,7 +15,7 @@ SAFETYHOOK_ROOT = Path(__file__).resolve().parent
 PUBLIC_INCLUDE_PATHS = [
     SAFETYHOOK_ROOT / 'include',
     SAFETYHOOK_ROOT / 'include' / 'safetyhook',
-    ]
+]
 INTERNAL_INCLUDE_PATHS = [SAFETYHOOK_ROOT / 'src']
 INCLUDE_REGEXP = re.compile(r'^#\s*include\s*"((?:safety).*)"\s*$')
 OUTPUT_DIR = SAFETYHOOK_ROOT / 'amalgamated-dist'

--- a/include/safetyhook.hpp
+++ b/include/safetyhook.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "safetyhook/os.hpp"
 #include "safetyhook/easy.hpp"
 #include "safetyhook/inline_hook.hpp"
 #include "safetyhook/mid_hook.hpp"


### PR DESCRIPTION
This is to avoid `#pragma once` being in the amalgamated source file.