### PR TITLE
Add CMake package config file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -179,10 +179,17 @@ if(SAFETYHOOK_USE_CXXMODULES)
 endif()
 
 include(GNUInstallDirs)
+include(CMakePackageConfigHelpers)
+
+configure_package_config_file(
+    ${CMAKE_CURRENT_SOURCE_DIR}/cmake/safetyhook-config.cmake.in
+    ${CMAKE_CURRENT_BINARY_DIR}/safetyhook-config.cmake
+    INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/safetyhook
+)
 
 install(
     TARGETS safetyhook
-    EXPORT safetyhook-export
+    EXPORT safetyhook-targets
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
@@ -195,9 +202,14 @@ install(
 )
 
 install(
-    EXPORT safetyhook-export
-    FILE safetyhook-config.cmake
+    EXPORT safetyhook-targets
+    FILE safetyhook-targets.cmake
     NAMESPACE safetyhook::
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/safetyhook
+)
+
+install(
+    FILES ${CMAKE_CURRENT_BINARY_DIR}/safetyhook-config.cmake
     DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/safetyhook
 )
 

--- a/cmake.toml
+++ b/cmake.toml
@@ -84,10 +84,17 @@ if(SAFETYHOOK_USE_CXXMODULES)
 endif()
 
 include(GNUInstallDirs)
+include(CMakePackageConfigHelpers)
+
+configure_package_config_file(
+    ${CMAKE_CURRENT_SOURCE_DIR}/cmake/safetyhook-config.cmake.in
+    ${CMAKE_CURRENT_BINARY_DIR}/safetyhook-config.cmake
+    INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/safetyhook
+)
 
 install(
     TARGETS safetyhook
-    EXPORT safetyhook-export
+    EXPORT safetyhook-targets
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
@@ -100,9 +107,14 @@ install(
 )
 
 install(
-    EXPORT safetyhook-export
-    FILE safetyhook-config.cmake
+    EXPORT safetyhook-targets
+    FILE safetyhook-targets.cmake
     NAMESPACE safetyhook::
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/safetyhook
+)
+
+install(
+    FILES ${CMAKE_CURRENT_BINARY_DIR}/safetyhook-config.cmake
     DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/safetyhook
 )
 """

--- a/cmake/safetyhook-config.cmake.in
+++ b/cmake/safetyhook-config.cmake.in
@@ -1,0 +1,7 @@
+@PACKAGE_INIT@
+
+include(CMakeFindDependencyMacro)
+find_dependency(zydis CONFIG)
+
+include("${CMAKE_CURRENT_LIST_DIR}/safetyhook-targets.cmake")
+check_required_components(safetyhook)


### PR DESCRIPTION
Minor change to allow `find_package(safetyhook)` to work without needing to also call `find_package(zydis)`

Related: https://github.com/microsoft/vcpkg/pull/43983#issuecomment-2683708190