### PR TITLE
Feature/Win7 support

### DIFF
--- a/src/os.windows.cpp
+++ b/src/os.windows.cpp
@@ -106,9 +106,10 @@ bool vm_is_writable(uint8_t* address, size_t size) {
 }
 
 bool vm_is_executable(uint8_t* address) {
-    LPVOID image_base_ptr;
-
-    if (RtlPcToFileHeader(address, &image_base_ptr) == nullptr) {
+    // Check if the address is in a valid module allowing us to potentially skip a heavier memory query.
+    HMODULE image_base_ptr{};
+    GetModuleHandleEx(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS, reinterpret_cast<LPTSTR>(address), &image_base_ptr);
+    if (image_base_ptr == nullptr) {
         return vm_query(address).value_or(VmBasicInfo{}).access.execute;
     }
 


### PR DESCRIPTION
This PR removes calls to APIs that don't exist on older versions of Windows (such as `RtlPcToFileHeader`).

Closes #99 