### PR TITLE
fix: correct mprotect size for unaligned addresses on linux

### DIFF
--- a/src/os.linux.cpp
+++ b/src/os.linux.cpp
@@ -82,6 +82,8 @@ std::expected<uint32_t, OsError> vm_protect(uint8_t* address, size_t size, uint3
 
     auto* addr = align_down(address, static_cast<size_t>(sysconf(_SC_PAGESIZE)));
 
+    size = size + static_cast<size_t>(address - addr);
+    
     if (mprotect(addr, size, static_cast<int>(protect)) == -1) {
         return std::unexpected{OsError::FAILED_TO_PROTECT};
     }


### PR DESCRIPTION
In the original implementation, if the memory address passed into ``vm_protect`` crosses a page boundary, the original ``size`` might not be large enough to cover the tail end of the region after alignment, leaving it with incorrect memory permissions, which can cause a segfault upon accessing/writing.

To fix this, we only need to add the alignment offset to the ``size`` to ensure the region has proper permissions. Even though this edge case is pretty rare imo, it is still nice to have it fixed to prevent crashes.

A poc to reproduce this:
```cpp
#include <sys/mman.h>
#include <unistd.h>
#include <cstdint>
#include <cstring>
#include <cstdio>

uint8_t* align_down(uint8_t* ptr, size_t alignment) {
    return reinterpret_cast<uint8_t*>(
        reinterpret_cast<uintptr_t>(ptr) & ~(alignment - 1)
    );
}

int main(int argc, char** argv) {
    size_t page_size = sysconf(_SC_PAGESIZE);
    uint8_t* memory = (uint8_t*)mmap(nullptr, page_size * 2, PROT_READ, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
    if (memory == MAP_FAILED) {
        printf("mmap failed\n");
        return 1;
    }

    uint8_t* target_address = memory + page_size - 2; 
    size_t target_size = 4;

    printf("[*] Target address: %p, size: %zu\n", target_address, target_size);

    uint8_t* aligned_addr = align_down(target_address, page_size);
    size_t mprotect_size = target_size;
    // the correct one: 
    // size_t mprotect_size = target_size + (target_address - aligned_addr); 

    if (mprotect(aligned_addr, mprotect_size, PROT_READ | PROT_WRITE) == -1) {
        printf("mprotect failed\n");
        return 1;
    }
    printf("Writing memory #1\n");
    target_address[0] = 0xAA; 
    target_address[1] = 0xBB; 

    printf("Writing memory #2\n");
    target_address[2] = 0xCC; 
    target_address[3] = 0xDD;

    printf("Passed\n");
    return 0;
}

```