### PR TITLE
fix: access violation calling disable in atexit

### DIFF
--- a/src/os.windows.cpp
+++ b/src/os.windows.cpp
@@ -274,6 +274,9 @@ void trap_threads(uint8_t* from, uint8_t* to, size_t len, const std::function<vo
     VirtualQuery(from, &from_mbi, sizeof(from_mbi));
     VirtualQuery(to, &to_mbi, sizeof(to_mbi));
 
+    if (from_mbi.Protect == PAGE_NOACCESS || to_mbi.Protect == PAGE_NOACCESS)
+        return;
+
     auto new_protect = PAGE_READWRITE;
 
     if (from_mbi.AllocationBase == find_me_mbi.AllocationBase || to_mbi.AllocationBase == find_me_mbi.AllocationBase) {

--- a/src/os.windows.cpp
+++ b/src/os.windows.cpp
@@ -274,8 +274,9 @@ void trap_threads(uint8_t* from, uint8_t* to, size_t len, const std::function<vo
     VirtualQuery(from, &from_mbi, sizeof(from_mbi));
     VirtualQuery(to, &to_mbi, sizeof(to_mbi));
 
-    if (from_mbi.Protect == PAGE_NOACCESS || to_mbi.Protect == PAGE_NOACCESS)
+    if (to_mbi.State != MEM_COMMIT) {
         return;
+    }
 
     auto new_protect = PAGE_READWRITE;
 


### PR DESCRIPTION
If you were to call disable on a mid/inline hook on Windows in atexit, it would error with an access violation in the callback that calls std::copy. Checking the query result for `Protect == PAGE_NOACCESS` on either from/to pointers would resolve this.