### PR TITLE
Fix optimized VMT hook tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ docs/html
 docs/latex
 docs/Doxyfile
 amalgamated-dist
+__build*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -507,6 +507,7 @@ if(SAFETYHOOK_BUILD_TEST) # build-test
 		"test/main.cpp"
 		"test/mid_hook.cpp"
 		"test/vmt_hook.cpp"
+		"test/vmt_targets.cpp"
 		cmake.toml
 	)
 
@@ -544,6 +545,7 @@ if(SAFETYHOOK_BUILD_TEST AND SAFETYHOOK_AMALGAMATE) # build-amalgamate-test
 		"test/main.cpp"
 		"test/mid_hook.cpp"
 		"test/vmt_hook.cpp"
+		"test/vmt_targets.cpp"
 		"amalgamated-dist/safetyhook.cpp"
 		cmake.toml
 	)

--- a/test/vmt_hook.cpp
+++ b/test/vmt_hook.cpp
@@ -1,7 +1,10 @@
 #include <boost/ut.hpp>
 #include <safetyhook.hpp>
 
+#include "vmt_targets.hpp"
+
 using namespace boost::ut;
+using namespace safetyhook::test;
 
 #if SAFETYHOOK_ABI_MSVC
 static constexpr auto VMT_OFFSET = 0;
@@ -11,23 +14,14 @@ static constexpr auto VMT_OFFSET = 1;
 
 static suite<"vmt hook"> vmt_hook_tests = [] {
     "VMT hook an object instance"_test = [] {
-        struct Interface {
-            virtual ~Interface() = default;
-            virtual int add_42(int a) = 0;
-        };
-
-        struct Target : Interface {
-            SAFETYHOOK_NOINLINE int add_42(int a) override { return a + 42; }
-        };
-
-        std::unique_ptr<Interface> target = std::make_unique<Target>();
+        auto target = make_single_target();
 
         expect(target->add_42(0) == 42_i);
 
         static SafetyHookVmt target_hook{};
         static SafetyHookVm add_42_hook{};
 
-        struct Hook : Target {
+        struct Hook : SingleTarget {
             int hooked_add_42(int a) { return add_42_hook.thiscall<int>(this, a) + 1337; }
         };
 
@@ -51,18 +45,7 @@ static suite<"vmt hook"> vmt_hook_tests = [] {
     };
 
     "Resetting the VMT hook removes all VM hooks for that object"_test = [] {
-        struct Interface {
-            virtual ~Interface() = default;
-            virtual int add_42(int a) = 0;
-            virtual int add_43(int a) = 0;
-        };
-
-        struct Target : Interface {
-            SAFETYHOOK_NOINLINE int add_42(int a) override { return a + 42; }
-            SAFETYHOOK_NOINLINE int add_43(int a) override { return a + 43; }
-        };
-
-        std::unique_ptr<Interface> target = std::make_unique<Target>();
+        auto target = make_dual_target();
 
         expect(target->add_42(0) == 42_i);
         expect(target->add_43(0) == 43_i);
@@ -71,7 +54,7 @@ static suite<"vmt hook"> vmt_hook_tests = [] {
         static SafetyHookVm add_42_hook{};
         static SafetyHookVm add_43_hook{};
 
-        struct Hook : Target {
+        struct Hook : DualTarget {
             int hooked_add_42(int a) { return add_42_hook.thiscall<int>(this, a) + 1337; }
             int hooked_add_43(int a) { return add_43_hook.thiscall<int>(this, a) + 1337; }
         };
@@ -105,24 +88,15 @@ static suite<"vmt hook"> vmt_hook_tests = [] {
     };
 
     "VMT hooking an object maintains correct RTTI"_test = [] {
-        struct Interface {
-            virtual ~Interface() = default;
-            virtual int add_42(int a) = 0;
-        };
-
-        struct Target : Interface {
-            SAFETYHOOK_NOINLINE int add_42(int a) override { return a + 42; }
-        };
-
-        auto target = std::make_unique<Target>();
+        auto target = make_single_target();
 
         expect(target->add_42(0) == 42_i);
-        expect(neq(dynamic_cast<Interface*>(target.get()), nullptr));
+        expect(neq(dynamic_cast<SingleInterface*>(target.get()), nullptr));
 
         static SafetyHookVmt target_hook{};
         static SafetyHookVm add_42_hook{};
 
-        struct Hook : Target {
+        struct Hook : SingleTarget {
             int hooked_add_42(int a) { return add_42_hook.thiscall<int>(this, a) + 1337; }
         };
 
@@ -139,27 +113,18 @@ static suite<"vmt hook"> vmt_hook_tests = [] {
         add_42_hook = std::move(*vm_result);
 
         expect(target->add_42(1) == 1380_i);
-        expect(neq(dynamic_cast<Interface*>(target.get()), nullptr));
+        expect(neq(dynamic_cast<SingleInterface*>(target.get()), nullptr));
     };
 
     "Can safely destroy VmtHook after object is deleted"_test = [] {
-        struct Interface {
-            virtual ~Interface() = default;
-            virtual int add_42(int a) = 0;
-        };
-
-        struct Target : Interface {
-            SAFETYHOOK_NOINLINE int add_42(int a) override { return a + 42; }
-        };
-
-        std::unique_ptr<Interface> target = std::make_unique<Target>();
+        auto target = make_single_target();
 
         expect(target->add_42(0) == 42_i);
 
         static SafetyHookVmt target_hook{};
         static SafetyHookVm add_42_hook{};
 
-        struct Hook : Target {
+        struct Hook : SingleTarget {
             int hooked_add_42(int a) { return add_42_hook.thiscall<int>(this, a) + 1337; }
         };
 
@@ -182,26 +147,17 @@ static suite<"vmt hook"> vmt_hook_tests = [] {
     };
 
     "Can apply an existing VMT hook to more than one object"_test = [] {
-        struct Interface {
-            virtual ~Interface() = default;
-            virtual int add_42(int a) = 0;
-        };
-
-        struct Target : Interface {
-            SAFETYHOOK_NOINLINE int add_42(int a) override { return a + 42; }
-        };
-
-        std::unique_ptr<Interface> target = std::make_unique<Target>();
-        std::unique_ptr<Interface> target0 = std::make_unique<Target>();
-        std::unique_ptr<Interface> target1 = std::make_unique<Target>();
-        std::unique_ptr<Interface> target2 = std::make_unique<Target>();
+        auto target = make_single_target();
+        auto target0 = make_single_target();
+        auto target1 = make_single_target();
+        auto target2 = make_single_target();
 
         expect(target->add_42(0) == 42_i);
 
         static SafetyHookVmt target_hook{};
         static SafetyHookVm add_42_hook{};
 
-        struct Hook : Target {
+        struct Hook : SingleTarget {
             int hooked_add_42(int a) { return add_42_hook.thiscall<int>(this, a) + 1337; }
         };
 
@@ -235,26 +191,17 @@ static suite<"vmt hook"> vmt_hook_tests = [] {
     };
 
     "Can remove an object that was previously VMT hooked"_test = [] {
-        struct Interface {
-            virtual ~Interface() = default;
-            virtual int add_42(int a) = 0;
-        };
-
-        struct Target : Interface {
-            SAFETYHOOK_NOINLINE int add_42(int a) override { return a + 42; }
-        };
-
-        std::unique_ptr<Interface> target = std::make_unique<Target>();
-        std::unique_ptr<Interface> target0 = std::make_unique<Target>();
-        std::unique_ptr<Interface> target1 = std::make_unique<Target>();
-        std::unique_ptr<Interface> target2 = std::make_unique<Target>();
+        auto target = make_single_target();
+        auto target0 = make_single_target();
+        auto target1 = make_single_target();
+        auto target2 = make_single_target();
 
         expect(target->add_42(0) == 42_i);
 
         static SafetyHookVmt target_hook{};
         static SafetyHookVm add_42_hook{};
 
-        struct Hook : Target {
+        struct Hook : SingleTarget {
             int hooked_add_42(int a) { return add_42_hook.thiscall<int>(this, a) + 1337; }
         };
 
@@ -309,23 +256,14 @@ static suite<"vmt hook"> vmt_hook_tests = [] {
     };
 
     "VMT hook an object instance with easy API"_test = [] {
-        struct Interface {
-            virtual ~Interface() = default;
-            virtual int add_42(int a) = 0;
-        };
-
-        struct Target : Interface {
-            SAFETYHOOK_NOINLINE int add_42(int a) override { return a + 42; }
-        };
-
-        std::unique_ptr<Interface> target = std::make_unique<Target>();
+        auto target = make_single_target();
 
         expect(target->add_42(0) == 42_i);
 
         static SafetyHookVmt target_hook{};
         static SafetyHookVm add_42_hook{};
 
-        struct Hook : Target {
+        struct Hook : SingleTarget {
             int hooked_add_42(int a) { return add_42_hook.thiscall<int>(this, a) + 1337; }
         };
 
@@ -340,29 +278,14 @@ static suite<"vmt hook"> vmt_hook_tests = [] {
     };
 
     "VMT hook preserves dynamic_cast with cross-cast"_test = [] {
-        struct Base1 {
-            virtual ~Base1() = default;
-            virtual int add_42(int a) = 0;
-        };
+        auto target = make_cast_target();
 
-        struct Base2 {
-            virtual ~Base2() = default;
-            virtual int add_1337(int a) = 0;
-        };
-
-        struct Target : Base1, Base2 {
-            SAFETYHOOK_NOINLINE int add_42(int a) override { return a + 42; }
-            SAFETYHOOK_NOINLINE int add_1337(int a) override { return a + 1337; }
-        };
-
-        auto target = std::make_unique<Target>();
-
-        Base2* base2 = target.get();
+        CastBase2* base2 = target.get();
 
         static SafetyHookVmt base2_hook{};
         static SafetyHookVm add_1337_hook{};
 
-        struct Hook : Target {
+        struct Hook : CastTarget {
             int hooked_add_1337(int a) { return add_1337_hook.thiscall<int>(this, a) + 42; }
         };
 
@@ -376,10 +299,10 @@ static suite<"vmt hook"> vmt_hook_tests = [] {
 
         expect(base2->add_1337(1) == 1380_i);
 
-        // Cross-cast: Base2* -> Base1*
-        // Runtime reads offset-to-top from Base2's vptr[-2]
+        // Cross-cast: CastBase2* -> CastBase1*
+        // Runtime reads offset-to-top from CastBase2's vptr[-2]
         // Without the fix this is garbage and will crash or return wrong pointer
-        Base1* base1 = dynamic_cast<Base1*>(base2);
+        CastBase1* base1 = dynamic_cast<CastBase1*>(base2);
         expect(neq(base1, nullptr));
         expect(base1->add_42(1) == 43_i);
 

--- a/test/vmt_targets.cpp
+++ b/test/vmt_targets.cpp
@@ -1,0 +1,18 @@
+#include "vmt_targets.hpp"
+
+// Keep target construction in a separate translation unit so optimized builds
+// cannot devirtualize the VMT hook tests and bypass the replaced vtable.
+
+namespace safetyhook::test {
+std::unique_ptr<SingleInterface> make_single_target() {
+    return std::make_unique<SingleTarget>();
+}
+
+std::unique_ptr<DualInterface> make_dual_target() {
+    return std::make_unique<DualTarget>();
+}
+
+std::unique_ptr<CastTarget> make_cast_target() {
+    return std::make_unique<CastTarget>();
+}
+} // namespace safetyhook::test

--- a/test/vmt_targets.hpp
+++ b/test/vmt_targets.hpp
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <memory>
+
+namespace safetyhook::test {
+struct SingleInterface {
+    virtual ~SingleInterface() = default;
+    virtual int add_42(int a) = 0;
+};
+
+struct SingleTarget : SingleInterface {
+    int add_42(int a) override { return a + 42; }
+};
+
+struct DualInterface {
+    virtual ~DualInterface() = default;
+    virtual int add_42(int a) = 0;
+    virtual int add_43(int a) = 0;
+};
+
+struct DualTarget : DualInterface {
+    int add_42(int a) override { return a + 42; }
+    int add_43(int a) override { return a + 43; }
+};
+
+struct CastBase1 {
+    virtual ~CastBase1() = default;
+    virtual int add_42(int a) = 0;
+};
+
+struct CastBase2 {
+    virtual ~CastBase2() = default;
+    virtual int add_1337(int a) = 0;
+};
+
+struct CastTarget : CastBase1, CastBase2 {
+    int add_42(int a) override { return a + 42; }
+    int add_1337(int a) override { return a + 1337; }
+};
+
+std::unique_ptr<SingleInterface> make_single_target();
+std::unique_ptr<DualInterface> make_dual_target();
+std::unique_ptr<CastTarget> make_cast_target();
+} // namespace safetyhook::test


### PR DESCRIPTION
## Summary

Refactors the VMT hook tests so target object construction happens in a separate translation unit. This prevents optimized GCC/MinGW builds from devirtualizing the test calls and bypassing the replaced vtable.

Also adds `__build*` to `.gitignore` for local build directories.

## Validation

```powershell
ctest --test-dir __build-relwithdebinfo-loop --output-on-failure
```

Result: 100% tests passed, 0 tests failed out of 2.