### PR TITLE
Update CPM bootstrap and dependencies.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,7 +57,7 @@ jobs:
 
       - name: Download & extract Zydis
         run: |
-          Invoke-WebRequest -Uri https://github.com/zyantific/zydis/releases/download/v4.0.0/zydis-amalgamated.zip -OutFile zydis.zip
+          Invoke-WebRequest -Uri https://github.com/zyantific/zydis/releases/download/v4.1.0/zydis-amalgamated.zip -OutFile zydis.zip
           Expand-Archive .\zydis.zip .
           Remove-Item .\zydis.zip
            @("#define ZYCORE_STATIC_BUILD", "#define ZYDIS_STATIC_BUILD") + (Get-Content -Raw .\amalgamated-dist\Zydis.h) | Set-Content -Encoding utf8 .\amalgamated-dist\Zydis.h

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,9 @@ endif()
 
 get_filename_component(CPM_DOWNLOAD_LOCATION "${CPM_DOWNLOAD_LOCATION}" ABSOLUTE)
 
+cmake_path(GET CPM_DOWNLOAD_LOCATION PARENT_PATH CPM_DOWNLOAD_DIR)
+file(MAKE_DIRECTORY "${CPM_DOWNLOAD_DIR}")
+
 if(NOT EXISTS "${CPM_DOWNLOAD_LOCATION}")
     file(DOWNLOAD
         "https://github.com/cpm-cmake/CPM.cmake/releases/download/v${CPM_DOWNLOAD_VERSION}/CPM.cmake"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,30 +19,38 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 include(GNUInstallDirs)
 include(CMakePackageConfigHelpers)
 
-set(CPM_DOWNLOAD_VERSION 0.40.8)
-set(CPM_DOWNLOAD_LOCATION "${CMAKE_CURRENT_BINARY_DIR}/cmake/CPM_${CPM_DOWNLOAD_VERSION}.cmake")
+set(CPM_DOWNLOAD_VERSION 0.42.3)
+set(CPM_HASH_SUM "a609e875fd532b067174250f6abbc3dac22fe2d64869783fb1e80bda1625c844")
+
+if(CPM_SOURCE_CACHE)
+    set(CPM_DOWNLOAD_LOCATION "${CPM_SOURCE_CACHE}/cpm/CPM_${CPM_DOWNLOAD_VERSION}.cmake")
+elseif(DEFINED ENV{CPM_SOURCE_CACHE})
+    set(CPM_DOWNLOAD_LOCATION "$ENV{CPM_SOURCE_CACHE}/cpm/CPM_${CPM_DOWNLOAD_VERSION}.cmake")
+else()
+    set(CPM_DOWNLOAD_LOCATION "${CMAKE_BINARY_DIR}/cmake/CPM_${CPM_DOWNLOAD_VERSION}.cmake")
+endif()
+
+get_filename_component(CPM_DOWNLOAD_LOCATION "${CPM_DOWNLOAD_LOCATION}" ABSOLUTE)
 
 if(NOT EXISTS "${CPM_DOWNLOAD_LOCATION}")
-    file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/cmake")
     file(DOWNLOAD
         "https://github.com/cpm-cmake/CPM.cmake/releases/download/v${CPM_DOWNLOAD_VERSION}/CPM.cmake"
         "${CPM_DOWNLOAD_LOCATION}"
-        EXPECTED_HASH SHA256=78ba32abdf798bc616bab7c73aac32a17bbd7b06ad9e26a6add69de8f3ae4791
+        EXPECTED_HASH SHA256=${CPM_HASH_SUM}
     )
 endif()
 
 include("${CPM_DOWNLOAD_LOCATION}")
 
 if(SAFETYHOOK_FETCH_ZYDIS)
-    set(ZYDIS_BUILD_EXAMPLES OFF CACHE BOOL "" FORCE)
-    set(ZYDIS_BUILD_TOOLS OFF CACHE BOOL "" FORCE)
-    set(ZYDIS_BUILD_DOXYGEN OFF CACHE BOOL "" FORCE)
-
+    # CPM.cmake shorthand syntax will add `EXCLUDE_FROM_ALL` and `SYSTEM` flag by default.
     CPMAddPackage(
-        NAME Zydis
-        GITHUB_REPOSITORY zyantific/zydis
-        GIT_TAG v4.1.0
-        EXCLUDE_FROM_ALL YES
+        URI "gh:zyantific/zydis@4.1.0"
+        OPTIONS
+            "ZYDIS_BUILD_EXAMPLES OFF"
+            "ZYDIS_BUILD_TOOLS OFF"
+            "ZYDIS_BUILD_DOXYGEN OFF"
+            "ZYDIS_BUILD_TESTS OFF"
     )
 else()
     find_package(Zydis REQUIRED CONFIG)
@@ -63,19 +71,9 @@ endif()
 if(SAFETYHOOK_BUILD_TEST)
     enable_testing()
 
-    CPMAddPackage(
-        NAME ut
-        GITHUB_REPOSITORY boost-ext/ut
-        GIT_TAG v2.0.1
-        EXCLUDE_FROM_ALL YES
-    )
+    CPMAddPackage("gh:boost-ext/ut@2.3.1")
 
-    CPMAddPackage(
-        NAME xbyak
-        GITHUB_REPOSITORY herumi/xbyak
-        GIT_TAG v7.30
-        EXCLUDE_FROM_ALL YES
-    )
+    CPMAddPackage("gh:herumi/xbyak@7.37.3")
 endif()
 
 add_subdirectory(src)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -8,7 +8,6 @@ set(SAFETYHOOK_TEST_SOURCES
 )
 
 add_executable(safetyhook-test ${SAFETYHOOK_TEST_SOURCES})
-set_target_properties(safetyhook-test PROPERTIES OUTPUT_NAME test)
 target_compile_features(safetyhook-test PRIVATE cxx_std_23)
 target_compile_definitions(safetyhook-test PRIVATE BOOST_UT_DISABLE_MODULE)
 target_link_libraries(safetyhook-test PRIVATE Boost::ut safetyhook::safetyhook xbyak::xbyak)
@@ -19,7 +18,6 @@ if(SAFETYHOOK_AMALGAMATE)
         ${SAFETYHOOK_TEST_SOURCES}
         "${PROJECT_SOURCE_DIR}/amalgamated-dist/safetyhook.cpp"
     )
-    set_target_properties(safetyhook-test-amalgamated PROPERTIES OUTPUT_NAME test-amalgamated)
     target_compile_features(safetyhook-test-amalgamated PRIVATE cxx_std_23)
     target_compile_definitions(safetyhook-test-amalgamated PRIVATE BOOST_UT_DISABLE_MODULE)
     target_include_directories(safetyhook-test-amalgamated PRIVATE "${PROJECT_SOURCE_DIR}/amalgamated-dist")

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,9 +1,6 @@
 {
-  "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg/master/scripts/vcpkg.schema.json",
+  "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "dependencies": [
-    "bddisasm"
-  ],
-  "description": "",
-  "name": "safetyhook",
-  "version-string": ""
+    "zydis"
+  ]
 }


### PR DESCRIPTION
- Bump CPM.cmake bootstrap from 0.40.8 to 0.42.3
- Add CPM_SOURCE_CACHE and ENV{CPM_SOURCE_CACHE} support
- Use CMAKE_BINARY_DIR and expand relative paths for CPM download
- Update dependencies:
    - Zydis via CPM URI shorthand with build options
    - ut 2.0.1 -> 2.3.1
    - xbyak 7.30 -> 7.37.3
- Align CI amalgamated Zydis download URL to v4.1.0
- Fix vcpkg.json dependency from bddisasm to zydis
- Remove unused vcpkg.json metadata
- Fix Linux build by removing OUTPUT_NAME from test targets

Tested on:
- Windows MSVC x64 / Win32
- Windows Clang x64 / x86
- WSL Ubuntu Clang 22 + libc++ x64