### PR TITLE
Fix Linux x86_32 test calling conventions.

### DIFF
--- a/test/inline_hook.cpp
+++ b/test/inline_hook.cpp
@@ -207,7 +207,11 @@ static suite<"inline hook"> inline_hook_tests = [] {
 #if SAFETYHOOK_OS_WINDOWS
         constexpr auto param = ecx;
 #elif SAFETYHOOK_OS_LINUX
+#if SAFETYHOOK_ARCH_X86_64
         constexpr auto param = edi;
+#elif SAFETYHOOK_ARCH_X86_32
+        auto param = dword[esp + 4];
+#endif
 #endif
 
         "JB"_test = [&] {

--- a/test/mid_hook.cpp
+++ b/test/mid_hook.cpp
@@ -25,7 +25,7 @@ static suite<"mid hook"> mid_hook_tests = [] {
 #if SAFETYHOOK_ARCH_X86_64
                 ctx.rdi = 1337 - 42;
 #elif SAFETYHOOK_ARCH_X86_32
-                ctx.edi = 1337 - 42;
+                *reinterpret_cast<int*>(ctx.esp + 4) = 1337 - 42;
 #endif
 #endif
             }
@@ -98,7 +98,7 @@ static suite<"mid hook"> mid_hook_tests = [] {
 #if SAFETYHOOK_ARCH_X86_64
                 ctx.rdi = 1337 - 42;
 #elif SAFETYHOOK_ARCH_X86_32
-                ctx.edi = 1337 - 42;
+                *reinterpret_cast<int*>(ctx.esp + 4) = 1337 - 42;
 #endif
 #endif
             }


### PR DESCRIPTION
SAFETYHOOK_FASTCALL is defined as empty on Linux, so test functions fall back to cdecl with arguments on the stack. The tests were incorrectly assuming register-based argument passing on Linux x86_32.

- test/inline_hook.cpp: use dword[esp + 4] as the parameter for generated assembly on Linux x86_32 instead of edi.
- test/mid_hook.cpp: modify the argument at [esp+4] instead of ctx.edi on Linux x86_32.

Tested on:
- WSL Ubuntu GCC 14 x86_32 (Debug)
- WSL Ubuntu GCC 14 x86_64 (Debug)