### PR TITLE
Expand CI build matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -173,54 +173,7 @@ jobs:
           cmake --build build --config ${{matrix.build_type}} --parallel
 
       - name: Test
-        if: matrix.os == 'windows-2022' && matrix.compiler != 'mingw'
-        shell: pwsh
-        run: |
-          $ErrorActionPreference = 'Continue'
-
-          function Invoke-TestBinary {
-            param(
-              [string] $Path,
-              [string] $Label
-            )
-
-            Write-Host "::group::$Label diagnostics"
-            Write-Host "pwd=$(Get-Location)"
-            Get-Item $Path | Format-List FullName,Length,LastWriteTime | Out-Host
-
-            Write-Host "$Label --list-tests"
-            & $Path --list-tests --use-colour no 2>&1 | Out-Host
-            Write-Host "$Label --list-tests exit=$LASTEXITCODE"
-
-            Write-Host "$Label --success --durations"
-            & $Path --success --durations --use-colour no 2>&1 | Out-Host
-            $exitCode = $LASTEXITCODE
-            Write-Host "$Label run exit=$exitCode"
-            Write-Host "::endgroup::"
-
-            return $exitCode
-          }
-
-          $testExit = Invoke-TestBinary "${{matrix.test_dir}}/test${{matrix.test_ext}}" "test"
-          $amalgamatedExit = Invoke-TestBinary "${{matrix.test_dir}}/test-amalgamated${{matrix.test_ext}}" "test-amalgamated"
-
-          if ($amalgamatedExit -ne 0) {
-            Write-Host "::group::test-amalgamated failure details"
-            & "${{matrix.test_dir}}/test-amalgamated${{matrix.test_ext}}" --list-reporters
-            Write-Host "list-reporters exit=$LASTEXITCODE"
-            & "${{matrix.test_dir}}/test-amalgamated${{matrix.test_ext}}" --libidentify
-            Write-Host "libidentify exit=$LASTEXITCODE"
-            Write-Host "::endgroup::"
-          }
-
-          if ($testExit -ne 0) {
-            exit $testExit
-          }
-
-          exit $amalgamatedExit
-
-      - name: Test
-        if: matrix.os != 'windows-2022' && matrix.compiler != 'mingw'
+        if: matrix.compiler != 'mingw'
         run: |
           ${{matrix.test_dir}}/test${{matrix.test_ext}}
           ${{matrix.test_dir}}/test-amalgamated${{matrix.test_ext}}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -114,7 +114,7 @@ jobs:
             compiler: clang
             build_type: Debug
             build_examples: OFF
-            configure_args: -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
+            configure_args: -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_CXX_FLAGS=-stdlib=libc++ -DCMAKE_EXE_LINKER_FLAGS=-stdlib=libc++
             test_dir: ./build
             test_ext: ""
           - os: ubuntu-24.04
@@ -122,7 +122,7 @@ jobs:
             compiler: clang
             build_type: Release
             build_examples: OFF
-            configure_args: -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
+            configure_args: -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_CXX_FLAGS=-stdlib=libc++ -DCMAKE_EXE_LINKER_FLAGS=-stdlib=libc++
             test_dir: ./build
             test_ext: ""
 
@@ -142,6 +142,12 @@ jobs:
             mingw-w64-x86_64-gcc
             mingw-w64-x86_64-ninja
             mingw-w64-x86_64-python
+
+      - name: Install libc++ for Clang
+        if: matrix.os == 'ubuntu-24.04' && matrix.compiler == 'clang'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libc++-dev libc++abi-dev
 
       - name: Configure
         if: matrix.compiler != 'mingw'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -83,6 +83,8 @@ jobs:
             compiler: mingw
             build_type: Debug
             build_examples: OFF
+            msystem: MINGW64
+            mingw_package_prefix: mingw-w64-x86_64
             configure_args: -G Ninja -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++
             test_dir: ./build
             test_ext: .exe
@@ -91,6 +93,28 @@ jobs:
             compiler: mingw
             build_type: Release
             build_examples: OFF
+            msystem: MINGW64
+            mingw_package_prefix: mingw-w64-x86_64
+            configure_args: -G Ninja -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++
+            test_dir: ./build
+            test_ext: .exe
+          - os: windows-2022
+            arch: x86
+            compiler: mingw
+            build_type: Debug
+            build_examples: OFF
+            msystem: MINGW32
+            mingw_package_prefix: mingw-w64-i686
+            configure_args: -G Ninja -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++
+            test_dir: ./build
+            test_ext: .exe
+          - os: windows-2022
+            arch: x86
+            compiler: mingw
+            build_type: Release
+            build_examples: OFF
+            msystem: MINGW32
+            mingw_package_prefix: mingw-w64-i686
             configure_args: -G Ninja -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++
             test_dir: ./build
             test_ext: .exe
@@ -111,11 +135,43 @@ jobs:
             test_dir: ./build
             test_ext: ""
           - os: ubuntu-24.04
+            arch: x86
+            compiler: gcc
+            build_type: Debug
+            build_examples: OFF
+            configure_args: -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_FLAGS=-m32 -DCMAKE_CXX_FLAGS=-m32 -DCMAKE_EXE_LINKER_FLAGS=-m32 -DCMAKE_SHARED_LINKER_FLAGS=-m32 -DCMAKE_MODULE_LINKER_FLAGS=-m32
+            test_dir: ./build
+            test_ext: ""
+          - os: ubuntu-24.04
+            arch: x86
+            compiler: gcc
+            build_type: Release
+            build_examples: OFF
+            configure_args: -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_FLAGS=-m32 -DCMAKE_CXX_FLAGS=-m32 -DCMAKE_EXE_LINKER_FLAGS=-m32 -DCMAKE_SHARED_LINKER_FLAGS=-m32 -DCMAKE_MODULE_LINKER_FLAGS=-m32
+            test_dir: ./build
+            test_ext: ""
+          - os: ubuntu-24.04
             arch: x64
             compiler: clang
             build_type: Debug
             build_examples: OFF
             configure_args: -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_CXX_FLAGS=-stdlib=libc++ -DCMAKE_EXE_LINKER_FLAGS=-stdlib=libc++
+            test_dir: ./build
+            test_ext: ""
+          - os: ubuntu-24.04
+            arch: x86
+            compiler: clang
+            build_type: Debug
+            build_examples: OFF
+            configure_args: -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_FLAGS=-m32 -DCMAKE_CXX_FLAGS='-m32 -stdlib=libc++' -DCMAKE_EXE_LINKER_FLAGS='-m32 -stdlib=libc++' -DCMAKE_SHARED_LINKER_FLAGS='-m32 -stdlib=libc++' -DCMAKE_MODULE_LINKER_FLAGS='-m32 -stdlib=libc++'
+            test_dir: ./build
+            test_ext: ""
+          - os: ubuntu-24.04
+            arch: x86
+            compiler: clang
+            build_type: Release
+            build_examples: OFF
+            configure_args: -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_FLAGS=-m32 -DCMAKE_CXX_FLAGS='-m32 -stdlib=libc++' -DCMAKE_EXE_LINKER_FLAGS='-m32 -stdlib=libc++' -DCMAKE_SHARED_LINKER_FLAGS='-m32 -stdlib=libc++' -DCMAKE_MODULE_LINKER_FLAGS='-m32 -stdlib=libc++'
             test_dir: ./build
             test_ext: ""
           - os: ubuntu-24.04
@@ -135,20 +191,32 @@ jobs:
         if: matrix.compiler == 'mingw'
         uses: msys2/setup-msys2@v2
         with:
-          msystem: MINGW64
+          msystem: ${{matrix.msystem}}
           update: true
           install: >-
             git
-            mingw-w64-x86_64-cmake
-            mingw-w64-x86_64-gcc
-            mingw-w64-x86_64-ninja
-            mingw-w64-x86_64-python
+            ${{matrix.mingw_package_prefix}}-cmake
+            ${{matrix.mingw_package_prefix}}-gcc
+            ${{matrix.mingw_package_prefix}}-ninja
+            ${{matrix.mingw_package_prefix}}-python
 
-      - name: Install libc++ for Clang
-        if: matrix.os == 'ubuntu-24.04' && matrix.compiler == 'clang'
+      - name: Install Linux x86 dependencies
+        if: matrix.os == 'ubuntu-24.04' && matrix.arch == 'x86'
+        run: |
+          sudo dpkg --add-architecture i386
+          sudo apt-get update
+          sudo apt-get install -y gcc-multilib g++-multilib libc6-dev-i386
+
+      - name: Install libc++ for Clang x64
+        if: matrix.os == 'ubuntu-24.04' && matrix.arch == 'x64' && matrix.compiler == 'clang'
         run: |
           sudo apt-get update
           sudo apt-get install -y libc++-dev libc++abi-dev
+
+      - name: Install libc++ for Clang x86
+        if: matrix.os == 'ubuntu-24.04' && matrix.arch == 'x86' && matrix.compiler == 'clang'
+        run: |
+          sudo apt-get install -y clang libc++-dev:i386 libc++abi-dev:i386
 
       - name: Configure
         if: matrix.compiler != 'mingw'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -173,7 +173,54 @@ jobs:
           cmake --build build --config ${{matrix.build_type}} --parallel
 
       - name: Test
-        if: matrix.compiler != 'mingw'
+        if: matrix.os == 'windows-2022' && matrix.compiler != 'mingw'
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Continue'
+
+          function Invoke-TestBinary {
+            param(
+              [string] $Path,
+              [string] $Label
+            )
+
+            Write-Host "::group::$Label diagnostics"
+            Write-Host "pwd=$(Get-Location)"
+            Get-Item $Path | Format-List FullName,Length,LastWriteTime | Out-Host
+
+            Write-Host "$Label --list-tests"
+            & $Path --list-tests --use-colour no 2>&1 | Out-Host
+            Write-Host "$Label --list-tests exit=$LASTEXITCODE"
+
+            Write-Host "$Label --success --durations"
+            & $Path --success --durations --use-colour no 2>&1 | Out-Host
+            $exitCode = $LASTEXITCODE
+            Write-Host "$Label run exit=$exitCode"
+            Write-Host "::endgroup::"
+
+            return $exitCode
+          }
+
+          $testExit = Invoke-TestBinary "${{matrix.test_dir}}/test${{matrix.test_ext}}" "test"
+          $amalgamatedExit = Invoke-TestBinary "${{matrix.test_dir}}/test-amalgamated${{matrix.test_ext}}" "test-amalgamated"
+
+          if ($amalgamatedExit -ne 0) {
+            Write-Host "::group::test-amalgamated failure details"
+            & "${{matrix.test_dir}}/test-amalgamated${{matrix.test_ext}}" --list-reporters
+            Write-Host "list-reporters exit=$LASTEXITCODE"
+            & "${{matrix.test_dir}}/test-amalgamated${{matrix.test_ext}}" --libidentify
+            Write-Host "libidentify exit=$LASTEXITCODE"
+            Write-Host "::endgroup::"
+          }
+
+          if ($testExit -ne 0) {
+            exit $testExit
+          }
+
+          exit $amalgamatedExit
+
+      - name: Test
+        if: matrix.os != 'windows-2022' && matrix.compiler != 'mingw'
         run: |
           ${{matrix.test_dir}}/test${{matrix.test_ext}}
           ${{matrix.test_dir}}/test-amalgamated${{matrix.test_ext}}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,7 @@ jobs:
     name: ${{matrix.os}} ${{matrix.arch}} ${{matrix.compiler}} ${{matrix.build_type}}
     runs-on: ${{matrix.os}}
     strategy:
+      fail-fast: false
       matrix:
         include:
           - os: windows-2022

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -129,7 +129,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v6.0.3
 
       - name: Set up MSYS2
         if: matrix.compiler == 'mingw'
@@ -190,20 +190,18 @@ jobs:
     needs: build
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v6.0.3
 
       - name: Amalgamate
         run: |
-          python3 amalgamate.py
+          python amalgamate.py
 
       - name: Compress amalgamated release
-        uses: vimtor/action-zip@v1.1
-        with:
-          files: amalgamated-dist/
-          dest: safetyhook-amalgamated.zip
+        run: |
+          Compress-Archive -Path amalgamated-dist -DestinationPath safetyhook-amalgamated.zip
 
       - name: Upload amalgamate
-        uses: actions/upload-artifact@v4.3.0
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: safetyhook-amalgamated
           path: amalgamated-dist/
@@ -216,19 +214,17 @@ jobs:
            @("#define ZYCORE_STATIC_BUILD", "#define ZYDIS_STATIC_BUILD") + (Get-Content -Raw .\amalgamated-dist\Zydis.h) | Set-Content -Encoding utf8 .\amalgamated-dist\Zydis.h
 
       - name: Compress amalgamated release with Zydis
-        uses: vimtor/action-zip@v1.1
-        with:
-          files: amalgamated-dist/
-          dest: safetyhook-amalgamated-zydis.zip
+        run: |
+          Compress-Archive -Path amalgamated-dist -DestinationPath safetyhook-amalgamated-zydis.zip
 
       - name: Upload amalgamate with Zydis
-        uses: actions/upload-artifact@v4.3.0
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: safetyhook-amalgamated-zydis
           path: amalgamated-dist/
 
       - name: Release
-        uses: softprops/action-gh-release@v0.1.15
+        uses: softprops/action-gh-release@v3.0.0
         if: startsWith(github.ref, 'refs/tags/')
         with:
           prerelease: ${{contains(github.ref, '-pre')}}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,30 +8,175 @@ on:
 
 jobs:
   build:
-    runs-on: windows-2022
+    name: ${{matrix.os}} ${{matrix.arch}} ${{matrix.compiler}} ${{matrix.build_type}}
+    runs-on: ${{matrix.os}}
     strategy:
       matrix:
-        arch: [ x64, Win32 ]
-        build_type: [ Debug, Release ]
+        include:
+          - os: windows-2022
+            arch: x64
+            compiler: msvc
+            build_type: Debug
+            build_examples: ON
+            configure_args: -A x64
+            test_dir: ./build/Debug
+            test_ext: .exe
+          - os: windows-2022
+            arch: x64
+            compiler: msvc
+            build_type: Release
+            build_examples: ON
+            configure_args: -A x64
+            test_dir: ./build/Release
+            test_ext: .exe
+          - os: windows-2022
+            arch: Win32
+            compiler: msvc
+            build_type: Debug
+            build_examples: ON
+            configure_args: -A Win32
+            test_dir: ./build/Debug
+            test_ext: .exe
+          - os: windows-2022
+            arch: Win32
+            compiler: msvc
+            build_type: Release
+            build_examples: ON
+            configure_args: -A Win32
+            test_dir: ./build/Release
+            test_ext: .exe
+          - os: windows-2022
+            arch: x64
+            compiler: clang-cl
+            build_type: Debug
+            build_examples: ON
+            configure_args: -A x64 -T ClangCL
+            test_dir: ./build/Debug
+            test_ext: .exe
+          - os: windows-2022
+            arch: x64
+            compiler: clang-cl
+            build_type: Release
+            build_examples: ON
+            configure_args: -A x64 -T ClangCL
+            test_dir: ./build/Release
+            test_ext: .exe
+          - os: windows-2022
+            arch: Win32
+            compiler: clang-cl
+            build_type: Debug
+            build_examples: ON
+            configure_args: -A Win32 -T ClangCL
+            test_dir: ./build/Debug
+            test_ext: .exe
+          - os: windows-2022
+            arch: Win32
+            compiler: clang-cl
+            build_type: Release
+            build_examples: ON
+            configure_args: -A Win32 -T ClangCL
+            test_dir: ./build/Release
+            test_ext: .exe
+          - os: windows-2022
+            arch: x64
+            compiler: mingw
+            build_type: Debug
+            build_examples: OFF
+            configure_args: -G Ninja -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++
+            test_dir: ./build
+            test_ext: .exe
+          - os: windows-2022
+            arch: x64
+            compiler: mingw
+            build_type: Release
+            build_examples: OFF
+            configure_args: -G Ninja -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++
+            test_dir: ./build
+            test_ext: .exe
+          - os: ubuntu-24.04
+            arch: x64
+            compiler: gcc
+            build_type: Debug
+            build_examples: OFF
+            configure_args: -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++
+            test_dir: ./build
+            test_ext: ""
+          - os: ubuntu-24.04
+            arch: x64
+            compiler: gcc
+            build_type: Release
+            build_examples: OFF
+            configure_args: -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++
+            test_dir: ./build
+            test_ext: ""
+          - os: ubuntu-24.04
+            arch: x64
+            compiler: clang
+            build_type: Debug
+            build_examples: OFF
+            configure_args: -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
+            test_dir: ./build
+            test_ext: ""
+          - os: ubuntu-24.04
+            arch: x64
+            compiler: clang
+            build_type: Release
+            build_examples: OFF
+            configure_args: -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
+            test_dir: ./build
+            test_ext: ""
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4.1.1
 
+      - name: Set up MSYS2
+        if: matrix.compiler == 'mingw'
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: MINGW64
+          update: true
+          install: >-
+            git
+            mingw-w64-x86_64-cmake
+            mingw-w64-x86_64-gcc
+            mingw-w64-x86_64-ninja
+            mingw-w64-x86_64-python
+
       - name: Configure
+        if: matrix.compiler != 'mingw'
         run: |
-          mkdir build
-          cd build
-          cmake -A ${{matrix.arch}} -DCMAKE_BUILD_TYPE=${{matrix.build_type}} -DSAFETYHOOK_FETCH_ZYDIS=ON -DSAFETYHOOK_BUILD_EXAMPLES=ON -DSAFETYHOOK_BUILD_TEST=ON -DSAFETYHOOK_AMALGAMATE=ON ..
+          cmake -B build ${{matrix.configure_args}} -DCMAKE_BUILD_TYPE=${{matrix.build_type}} -DSAFETYHOOK_FETCH_ZYDIS=ON -DSAFETYHOOK_BUILD_EXAMPLES=${{matrix.build_examples}} -DSAFETYHOOK_BUILD_TEST=ON -DSAFETYHOOK_AMALGAMATE=ON .
+
+      - name: Configure
+        if: matrix.compiler == 'mingw'
+        shell: msys2 {0}
+        run: |
+          cmake -B build ${{matrix.configure_args}} -DCMAKE_BUILD_TYPE=${{matrix.build_type}} -DSAFETYHOOK_FETCH_ZYDIS=ON -DSAFETYHOOK_BUILD_EXAMPLES=${{matrix.build_examples}} -DSAFETYHOOK_BUILD_TEST=ON -DSAFETYHOOK_AMALGAMATE=ON .
 
       - name: Build
+        if: matrix.compiler != 'mingw'
+        run: |
+          cmake --build build --config ${{matrix.build_type}} --parallel
+
+      - name: Build
+        if: matrix.compiler == 'mingw'
+        shell: msys2 {0}
         run: |
           cmake --build build --config ${{matrix.build_type}} --parallel
 
       - name: Test
+        if: matrix.compiler != 'mingw'
         run: |
-          ./build/${{matrix.build_type}}/test.exe
-          ./build/${{matrix.build_type}}/test-amalgamated.exe
+          ${{matrix.test_dir}}/test${{matrix.test_ext}}
+          ${{matrix.test_dir}}/test-amalgamated${{matrix.test_ext}}
+
+      - name: Test
+        if: matrix.compiler == 'mingw'
+        shell: msys2 {0}
+        run: |
+          ${{matrix.test_dir}}/test${{matrix.test_ext}}
+          ${{matrix.test_dir}}/test-amalgamated${{matrix.test_ext}}
 
   amalgamated-dist:
     runs-on: windows-2022

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,12 +38,14 @@ project(safetyhook)
 include(FetchContent)
 
 if(SAFETYHOOK_BUILD_TEST) # build-test
-	message(STATUS "Fetching ut (v2.0.1)...")
+	set(BOOST_UT_DISABLE_MODULE ON CACHE BOOL "" FORCE)
+
+	message(STATUS "Fetching ut (v2.3.1)...")
 	FetchContent_Declare(ut
 		GIT_REPOSITORY
 			"https://github.com/boost-ext/ut.git"
 		GIT_TAG
-			v2.0.1
+			v2.3.1
 		GIT_SHALLOW
 			ON
 		EXCLUDE_FROM_ALL

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,20 +38,22 @@ project(safetyhook)
 include(FetchContent)
 
 if(SAFETYHOOK_BUILD_TEST) # build-test
-	set(BOOST_UT_DISABLE_MODULE ON CACHE BOOL "" FORCE)
+	set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+	set(INSTALL_GTEST OFF CACHE BOOL "" FORCE)
+	set(BUILD_GMOCK OFF CACHE BOOL "" FORCE)
 
-	message(STATUS "Fetching ut (v2.3.1)...")
-	FetchContent_Declare(ut
+	message(STATUS "Fetching googletest (v1.15.2)...")
+	FetchContent_Declare(googletest
 		GIT_REPOSITORY
-			"https://github.com/boost-ext/ut.git"
+			"https://github.com/google/googletest.git"
 		GIT_TAG
-			v2.3.1
+			v1.15.2
 		GIT_SHALLOW
 			ON
 		EXCLUDE_FROM_ALL
 			ON
 	)
-	FetchContent_MakeAvailable(ut)
+	FetchContent_MakeAvailable(googletest)
 
 endif()
 if(SAFETYHOOK_BUILD_TEST) # build-test
@@ -518,16 +520,12 @@ if(SAFETYHOOK_BUILD_TEST) # build-test
 	target_sources(test PRIVATE ${test_SOURCES})
 	source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} FILES ${test_SOURCES})
 
-	target_compile_definitions(test PRIVATE
-		BOOST_UT_DISABLE_MODULE
-	)
-
 	target_compile_features(test PRIVATE
 		cxx_std_23
 	)
 
 	target_link_libraries(test PRIVATE
-		Boost::ut
+		GTest::gtest
 		safetyhook::safetyhook
 		xbyak::xbyak
 	)
@@ -557,10 +555,6 @@ if(SAFETYHOOK_BUILD_TEST AND SAFETYHOOK_AMALGAMATE) # build-amalgamate-test
 	target_sources(test-amalgamated PRIVATE ${test-amalgamated_SOURCES})
 	source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} FILES ${test-amalgamated_SOURCES})
 
-	target_compile_definitions(test-amalgamated PRIVATE
-		BOOST_UT_DISABLE_MODULE
-	)
-
 	target_compile_features(test-amalgamated PRIVATE
 		cxx_std_23
 	)
@@ -571,7 +565,7 @@ if(SAFETYHOOK_BUILD_TEST AND SAFETYHOOK_AMALGAMATE) # build-amalgamate-test
 
 	target_link_libraries(test-amalgamated PRIVATE
 		Zydis
-		Boost::ut
+		GTest::gtest
 		xbyak::xbyak
 	)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -507,6 +507,7 @@ if(SAFETYHOOK_BUILD_TEST) # build-test
 		"test/main.cpp"
 		"test/mid_hook.cpp"
 		"test/vmt_hook.cpp"
+		"test/vmt_targets.cpp"
 		cmake.toml
 	)
 
@@ -544,6 +545,7 @@ if(SAFETYHOOK_BUILD_TEST AND SAFETYHOOK_AMALGAMATE) # build-amalgamate-test
 		"test/main.cpp"
 		"test/mid_hook.cpp"
 		"test/vmt_hook.cpp"
+		"test/vmt_targets.cpp"
 		"amalgamated-dist/safetyhook.cpp"
 		cmake.toml
 	)

--- a/cmake.toml
+++ b/cmake.toml
@@ -26,13 +26,15 @@ fetch-zydis = "SAFETYHOOK_FETCH_ZYDIS"
 find-zydis = "(NOT SAFETYHOOK_FETCH_ZYDIS)"
 build-module = "SAFETYHOOK_BUILD_MODULE"
 
-[fetch-content.ut]
+[fetch-content.googletest]
 condition = "build-test"
-git = "https://github.com/boost-ext/ut.git"
-tag = "v2.3.1"
+git = "https://github.com/google/googletest.git"
+tag = "v1.15.2"
 shallow = true
 cmake-before = """
-set(BOOST_UT_DISABLE_MODULE ON CACHE BOOL "" FORCE)
+set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+set(INSTALL_GTEST OFF CACHE BOOL "" FORCE)
+set(BUILD_GMOCK OFF CACHE BOOL "" FORCE)
 """
 EXCLUDE_FROM_ALL = true
 
@@ -240,8 +242,7 @@ properties.CXX_SCAN_FOR_MODULES = true
 condition = "build-test"
 type = "executable"
 sources = ["test/*.cpp"]
-link-libraries = ["Boost::ut", "safetyhook::safetyhook", "xbyak::xbyak"]
-compile-definitions = ["BOOST_UT_DISABLE_MODULE"]
+link-libraries = ["GTest::gtest", "safetyhook::safetyhook", "xbyak::xbyak"]
 compile-features = ["cxx_std_23"]
 
 [target.test-amalgamated]
@@ -249,8 +250,7 @@ condition = "build-amalgamate-test"
 type = "executable"
 sources = ["test/*.cpp", "amalgamated-dist/safetyhook.cpp"]
 include-directories = ["amalgamated-dist/"]
-link-libraries = ["Zydis", "Boost::ut", "xbyak::xbyak"]
-compile-definitions = ["BOOST_UT_DISABLE_MODULE"]
+link-libraries = ["Zydis", "GTest::gtest", "xbyak::xbyak"]
 compile-features = ["cxx_std_23"]
 cmake-after = """
 add_dependencies(test-amalgamated Amalgamate)

--- a/cmake.toml
+++ b/cmake.toml
@@ -29,8 +29,11 @@ build-module = "SAFETYHOOK_BUILD_MODULE"
 [fetch-content.ut]
 condition = "build-test"
 git = "https://github.com/boost-ext/ut.git"
-tag = "v2.0.1"
+tag = "v2.3.1"
 shallow = true
+cmake-before = """
+set(BOOST_UT_DISABLE_MODULE ON CACHE BOOL "" FORCE)
+"""
 EXCLUDE_FROM_ALL = true
 
 [fetch-content.xbyak]

--- a/include/safetyhook/common.hpp
+++ b/include/safetyhook/common.hpp
@@ -77,7 +77,9 @@
 
 #if SAFETYHOOK_COMPILER_MSVC
 #define SAFETYHOOK_NOINLINE __declspec(noinline)
-#elif SAFETYHOOK_COMPILER_GCC || SAFETYHOOK_COMPILER_CLANG
+#elif SAFETYHOOK_COMPILER_GCC
+#define SAFETYHOOK_NOINLINE __attribute__((noinline, noipa))
+#elif SAFETYHOOK_COMPILER_CLANG
 #define SAFETYHOOK_NOINLINE __attribute__((noinline))
 #endif
 

--- a/include/safetyhook/common.hpp
+++ b/include/safetyhook/common.hpp
@@ -78,7 +78,7 @@
 #if SAFETYHOOK_COMPILER_MSVC
 #define SAFETYHOOK_NOINLINE __declspec(noinline)
 #elif SAFETYHOOK_COMPILER_GCC
-#define SAFETYHOOK_NOINLINE __attribute__((noinline, noipa))
+#define SAFETYHOOK_NOINLINE __attribute__((noinline))
 #elif SAFETYHOOK_COMPILER_CLANG
 #define SAFETYHOOK_NOINLINE __attribute__((noinline))
 #endif

--- a/src/inline_hook.cpp
+++ b/src/inline_hook.cpp
@@ -1,4 +1,5 @@
 #include <iterator>
+#include <optional>
 
 #if __has_include("Zydis/Zydis.h")
 #include "Zydis/Zydis.h"
@@ -113,6 +114,42 @@ static bool decode(ZydisDecodedInstruction* ix, uint8_t* ip) {
 
     return ZYAN_SUCCESS(ZydisDecoderDecodeInstruction(&decoder, nullptr, ip, 15, ix));
 }
+
+#if SAFETYHOOK_ARCH_X86_32
+static std::optional<uint8_t> x86_get_pc_thunk_register(uint8_t* ip, const ZydisDecodedInstruction& ix) {
+    if (ix.mnemonic != ZYDIS_MNEMONIC_CALL || ix.raw.imm[0].size != 32) {
+        return std::nullopt;
+    }
+
+    const auto* thunk_ip = ip + ix.length + static_cast<int32_t>(ix.raw.imm[0].value.s);
+    ZydisDecodedInstruction mov_ix{};
+    ZydisDecodedInstruction ret_ix{};
+
+    if (!decode(&mov_ix, const_cast<uint8_t*>(thunk_ip)) ||
+        !decode(&ret_ix, const_cast<uint8_t*>(thunk_ip + mov_ix.length))) {
+        return std::nullopt;
+    }
+
+    // GNU i386 PIC thunks have this body: mov r32, [esp]; ret.
+    if (mov_ix.mnemonic != ZYDIS_MNEMONIC_MOV || mov_ix.length != 3 || ret_ix.mnemonic != ZYDIS_MNEMONIC_RET ||
+        ret_ix.length != 1 || thunk_ip[0] != 0x8B || thunk_ip[2] != 0x24 || thunk_ip[mov_ix.length] != 0xC3) {
+        return std::nullopt;
+    }
+
+    const auto modrm = thunk_ip[1];
+
+    if ((modrm & 0xC7) != 0x04) {
+        return std::nullopt;
+    }
+
+    return (modrm >> 3) & 0x07;
+}
+
+static void emit_mov_r32_imm32(uint8_t* ip, uint8_t reg, uint8_t* value) {
+    *ip = static_cast<uint8_t>(0xB8 + reg);
+    store(ip + 1, static_cast<uint32_t>(reinterpret_cast<uintptr_t>(value)));
+}
+#endif
 
 std::expected<InlineHook, InlineHook::Error> InlineHook::create(void* target, void* destination, Flags flags) {
     return create(Allocator::global(), target, destination, flags);
@@ -245,7 +282,16 @@ std::expected<void, InlineHook::Error> InlineHook::e9_hook(const std::shared_ptr
 
         const auto is_relative = (ix.attributes & ZYDIS_ATTRIB_IS_RELATIVE) != 0;
 
-        if (is_relative && ix.raw.disp.size == 32) {
+        if (
+#if SAFETYHOOK_ARCH_X86_32
+            auto thunk_reg = x86_get_pc_thunk_register(ip, ix);
+            thunk_reg
+        ) {
+            emit_mov_r32_imm32(tramp_ip, *thunk_reg, ip + ix.length);
+            tramp_ip += ix.length;
+        } else if (
+#endif
+            is_relative && ix.raw.disp.size == 32) {
             std::copy_n(ip, ix.length, tramp_ip);
             const auto target_address = ip + ix.length + ix.raw.disp.value;
             const auto new_disp = target_address - (tramp_ip + ix.length);

--- a/src/os.linux.cpp
+++ b/src/os.linux.cpp
@@ -103,8 +103,8 @@ std::expected<VmBasicInfo, OsError> vm_query(uint8_t* address) {
     unsigned long end;
     char perms[5];
     unsigned long offset;
-    int dev_major;
-    int dev_minor;
+    unsigned int dev_major;
+    unsigned int dev_minor;
     unsigned long inode;
     char path[256];
     unsigned long last_end =
@@ -115,8 +115,10 @@ std::expected<VmBasicInfo, OsError> vm_query(uint8_t* address) {
     while (fgets(line, sizeof(line), maps) != nullptr) {
         path[0] = '\0';
 
-        sscanf(line, "%lx-%lx %4s %lx %x:%x %lu %255[^\n]", &start, &end, perms, &offset, &dev_major, &dev_minor,
-            &inode, path);
+        if (sscanf(line, "%lx-%lx %4s %lx %x:%x %lu %255[^\n]", &start, &end, perms, &offset, &dev_major, &dev_minor,
+                &inode, path) < 7) {
+            continue;
+        }
 
         if (last_end < start && addr >= last_end && addr < start) {
             info = std::make_optional<VmBasicInfo>(

--- a/src/os.linux.cpp
+++ b/src/os.linux.cpp
@@ -3,6 +3,7 @@
 #if SAFETYHOOK_OS_LINUX
 
 #include <cstdio>
+#include <limits>
 
 #include <sys/mman.h>
 #include <unistd.h>
@@ -176,7 +177,11 @@ SystemInfo system_info() {
     info.page_size = page_size;
     info.allocation_granularity = page_size;
     info.min_address = reinterpret_cast<uint8_t*>(0x10000);
-    info.max_address = reinterpret_cast<uint8_t*>(1ull << 47);
+#if SAFETYHOOK_ARCH_X86_64
+    info.max_address = reinterpret_cast<uint8_t*>(uintptr_t{1} << 47);
+#elif SAFETYHOOK_ARCH_X86_32
+    info.max_address = reinterpret_cast<uint8_t*>(std::numeric_limits<uintptr_t>::max());
+#endif
 
     return info;
 }

--- a/test/allocator.cpp
+++ b/test/allocator.cpp
@@ -3,7 +3,8 @@
 
 using namespace boost::ut;
 
-static suite<"allocator"> allocator_tests = [] {
+void register_allocator_tests() {
+suite<"allocator"> allocator_tests = [] {
     "Allocator reuses freed memory"_test = [] {
         const auto allocator = safetyhook::Allocator::create();
         auto first_allocation = allocator->allocate(128);
@@ -29,3 +30,4 @@ static suite<"allocator"> allocator_tests = [] {
         expect(eq(fourth_allocation->address(), third_allocation->address() + 64));
     };
 };
+}

--- a/test/allocator.cpp
+++ b/test/allocator.cpp
@@ -1,33 +1,27 @@
-#include <boost/ut.hpp>
+#include <gtest/gtest.h>
 #include <safetyhook.hpp>
 
-using namespace boost::ut;
+TEST(Allocator, AllocatorReusesFreedMemory) {
+    const auto allocator = safetyhook::Allocator::create();
+    auto first_allocation = allocator->allocate(128);
 
-void register_allocator_tests() {
-suite<"allocator"> allocator_tests = [] {
-    "Allocator reuses freed memory"_test = [] {
-        const auto allocator = safetyhook::Allocator::create();
-        auto first_allocation = allocator->allocate(128);
+    ASSERT_TRUE(first_allocation.has_value());
 
-        expect(first_allocation.has_value());
+    const auto first_allocation_address = first_allocation->address();
+    const auto second_allocation = allocator->allocate(256);
 
-        const auto first_allocation_address = first_allocation->address();
-        const auto second_allocation = allocator->allocate(256);
+    ASSERT_TRUE(second_allocation.has_value());
+    EXPECT_NE(second_allocation->address(), first_allocation_address);
 
-        expect(second_allocation.has_value());
-        expect(neq(second_allocation->address(), first_allocation_address));
+    first_allocation->free();
 
-        first_allocation->free();
+    const auto third_allocation = allocator->allocate(64);
 
-        const auto third_allocation = allocator->allocate(64);
+    ASSERT_TRUE(third_allocation.has_value());
+    EXPECT_EQ(third_allocation->address(), first_allocation_address);
 
-        expect(third_allocation.has_value());
-        expect(eq(third_allocation->address(), first_allocation_address));
+    const auto fourth_allocation = allocator->allocate(64);
 
-        const auto fourth_allocation = allocator->allocate(64);
-
-        expect(fourth_allocation.has_value());
-        expect(eq(fourth_allocation->address(), third_allocation->address() + 64));
-    };
-};
+    ASSERT_TRUE(fourth_allocation.has_value());
+    EXPECT_EQ(fourth_allocation->address(), third_allocation->address() + 64);
 }

--- a/test/inline_hook.cpp
+++ b/test/inline_hook.cpp
@@ -19,10 +19,12 @@ TEST(InlineHook, FunctionHookedMultipleTimes) {
     EXPECT_EQ(Target::fn("world"), "hello world"sv);
 
     // First hook.
-    static SafetyHookInline hook0;
+    static SafetyHookInline* hook0_ptr{};
+    SafetyHookInline hook0;
+    hook0_ptr = &hook0;
 
     struct Hook0 {
-        static std::string fn(std::string name) { return hook0.call<std::string>(name + " and bob"); }
+        static std::string fn(std::string name) { return hook0_ptr->call<std::string>(name + " and bob"); }
     };
 
     auto hook0_result = SafetyHookInline::create(Target::fn, Hook0::fn);
@@ -34,10 +36,12 @@ TEST(InlineHook, FunctionHookedMultipleTimes) {
     EXPECT_EQ(Target::fn("world"), "hello world and bob"sv);
 
     // Second hook.
-    static SafetyHookInline hook1;
+    static SafetyHookInline* hook1_ptr{};
+    SafetyHookInline hook1;
+    hook1_ptr = &hook1;
 
     struct Hook1 {
-        static std::string fn(std::string name) { return hook1.call<std::string>(name + " and alice"); }
+        static std::string fn(std::string name) { return hook1_ptr->call<std::string>(name + " and alice"); }
     };
 
     auto hook1_result = SafetyHookInline::create(Target::fn, Hook1::fn);
@@ -49,10 +53,12 @@ TEST(InlineHook, FunctionHookedMultipleTimes) {
     EXPECT_EQ(Target::fn("world"), "hello world and alice and bob"sv);
 
     // Third hook.
-    static SafetyHookInline hook2;
+    static SafetyHookInline* hook2_ptr{};
+    SafetyHookInline hook2;
+    hook2_ptr = &hook2;
 
     struct Hook2 {
-        static std::string fn(std::string name) { return hook2.call<std::string>(name + " and eve"); }
+        static std::string fn(std::string name) { return hook2_ptr->call<std::string>(name + " and eve"); }
     };
 
     auto hook2_result = SafetyHookInline::create(Target::fn, Hook2::fn);
@@ -64,10 +70,12 @@ TEST(InlineHook, FunctionHookedMultipleTimes) {
     EXPECT_EQ(Target::fn("world"), "hello world and eve and alice and bob"sv);
 
     // Fourth hook.
-    static SafetyHookInline hook3;
+    static SafetyHookInline* hook3_ptr{};
+    SafetyHookInline hook3;
+    hook3_ptr = &hook3;
 
     struct Hook3 {
-        static std::string fn(std::string name) { return hook3.call<std::string>(name + " and carol"); }
+        static std::string fn(std::string name) { return hook3_ptr->call<std::string>(name + " and carol"); }
     };
 
     auto hook3_result = SafetyHookInline::create(Target::fn, Hook3::fn);
@@ -90,12 +98,18 @@ TEST(InlineHook, FunctionWithMultipleArgsHooked) {
         SAFETYHOOK_NOINLINE static int add(int x, int y) { return x + y; }
     };
 
-    EXPECT_EQ(Target::add(2, 3), 5);
+    using AddFn = int (*)(int, int);
+    // Force a real indirect call so MinGW Release cannot optimize around runtime patching.
+    AddFn volatile add = Target::add;
 
-    static SafetyHookInline add_hook;
+    EXPECT_EQ(add(2, 3), 5);
+
+    static SafetyHookInline* add_hook_ptr{};
+    SafetyHookInline add_hook;
+    add_hook_ptr = &add_hook;
 
     struct AddHook {
-        static int add(int x, int y) { return add_hook.call<int>(x * 2, y * 2); }
+        static int add(int x, int y) { return add_hook_ptr->call<int>(x * 2, y * 2); }
     };
 
     auto add_hook_result = SafetyHookInline::create(Target::add, AddHook::add);
@@ -104,11 +118,11 @@ TEST(InlineHook, FunctionWithMultipleArgsHooked) {
 
     add_hook = std::move(*add_hook_result);
 
-    EXPECT_EQ(Target::add(3, 4), 14);
+    EXPECT_EQ(add(3, 4), 14);
 
     add_hook.reset();
 
-    EXPECT_EQ(Target::add(5, 6), 11);
+    EXPECT_EQ(add(5, 6), 11);
 }
 
 #if SAFETYHOOK_OS_WINDOWS
@@ -155,10 +169,12 @@ TEST(InlineHook, ActiveFunctionIsHookedAndUnhooked) {
         std::this_thread::yield();
     }
 
-    static SafetyHookInline hook;
+    static SafetyHookInline* hook_ptr{};
+    SafetyHookInline hook;
+    hook_ptr = &hook;
 
     struct Hook {
-        static std::string say_hello(int times [[maybe_unused]]) { return hook.call<std::string>(1337); }
+        static std::string say_hello(int times [[maybe_unused]]) { return hook_ptr->call<std::string>(1337); }
     };
 
     const auto stop_worker = [&] {
@@ -204,10 +220,12 @@ TEST(InlineHook, ActiveFunctionIsHookedAndUnhooked) {
 #endif
 
 TEST(InlineHook, FunctionWithShortUnconditionalBranchIsHooked) {
-    static SafetyHookInline hook;
+    static SafetyHookInline* hook_ptr{};
+    SafetyHookInline hook;
+    hook_ptr = &hook;
 
     struct Hook {
-        static int SAFETYHOOK_FASTCALL fn() { return hook.fastcall<int>() + 42; };
+        static int SAFETYHOOK_FASTCALL fn() { return hook_ptr->fastcall<int>() + 42; };
     };
 
     Xbyak::CodeGenerator cg{};
@@ -235,10 +253,12 @@ TEST(InlineHook, FunctionWithShortUnconditionalBranchIsHooked) {
 }
 
 TEST(InlineHook, FunctionWithShortConditionalBranchIsHooked) {
-    static SafetyHookInline hook;
+    static SafetyHookInline* hook_ptr{};
+    SafetyHookInline hook;
+    hook_ptr = &hook;
 
     struct Hook {
-        static int SAFETYHOOK_FASTCALL fn(int x) { return hook.fastcall<int>(x) + 42; };
+        static int SAFETYHOOK_FASTCALL fn(int x) { return hook_ptr->fastcall<int>(x) + 42; };
     };
 
     Xbyak::CodeGenerator cg{};
@@ -679,10 +699,12 @@ TEST(InlineHook, FunctionWithShortJumpInsideTrampoline) {
 
     EXPECT_EQ(fn(), 42);
 
-    static SafetyHookInline hook;
+    static SafetyHookInline* hook_ptr{};
+    SafetyHookInline hook;
+    hook_ptr = &hook;
 
     struct Hook {
-        static int fn() { return hook.call<int>() + 1; }
+        static int fn() { return hook_ptr->call<int>() + 1; }
     };
 
     hook = safetyhook::create_inline(fn, Hook::fn);
@@ -702,14 +724,20 @@ TEST(InlineHook, FunctionHookCanBeEnableAndDisabled) {
         }
     };
 
-    EXPECT_EQ(Target::fn(1), 2);
-    EXPECT_EQ(Target::fn(2), 4);
-    EXPECT_EQ(Target::fn(3), 6);
+    using Fn = int (*)(int);
+    // Force a real indirect call so MinGW Release cannot optimize around runtime patching.
+    Fn volatile fn = Target::fn;
 
-    static SafetyHookInline hook;
+    EXPECT_EQ(fn(1), 2);
+    EXPECT_EQ(fn(2), 4);
+    EXPECT_EQ(fn(3), 6);
+
+    static SafetyHookInline* hook_ptr{};
+    SafetyHookInline hook;
+    hook_ptr = &hook;
 
     struct Hook {
-        static int fn(int a) { return hook.call<int>(a + 1); }
+        static int fn(int a) { return hook_ptr->call<int>(a + 1); }
     };
 
     auto hook0_result = SafetyHookInline::create(Target::fn, Hook::fn, SafetyHookInline::StartDisabled);
@@ -718,25 +746,25 @@ TEST(InlineHook, FunctionHookCanBeEnableAndDisabled) {
 
     hook = std::move(*hook0_result);
 
-    EXPECT_EQ(Target::fn(1), 2);
-    EXPECT_EQ(Target::fn(2), 4);
-    EXPECT_EQ(Target::fn(3), 6);
+    EXPECT_EQ(fn(1), 2);
+    EXPECT_EQ(fn(2), 4);
+    EXPECT_EQ(fn(3), 6);
 
     ASSERT_TRUE(hook.enable().has_value());
 
-    EXPECT_EQ(Target::fn(1), 4);
-    EXPECT_EQ(Target::fn(2), 6);
-    EXPECT_EQ(Target::fn(3), 8);
+    EXPECT_EQ(fn(1), 4);
+    EXPECT_EQ(fn(2), 6);
+    EXPECT_EQ(fn(3), 8);
 
     ASSERT_TRUE(hook.disable().has_value());
 
-    EXPECT_EQ(Target::fn(1), 2);
-    EXPECT_EQ(Target::fn(2), 4);
-    EXPECT_EQ(Target::fn(3), 6);
+    EXPECT_EQ(fn(1), 2);
+    EXPECT_EQ(fn(2), 4);
+    EXPECT_EQ(fn(3), 6);
 
     hook.reset();
 
-    EXPECT_EQ(Target::fn(1), 2);
-    EXPECT_EQ(Target::fn(2), 4);
-    EXPECT_EQ(Target::fn(3), 6);
+    EXPECT_EQ(fn(1), 2);
+    EXPECT_EQ(fn(2), 4);
+    EXPECT_EQ(fn(3), 6);
 }

--- a/test/inline_hook.cpp
+++ b/test/inline_hook.cpp
@@ -8,7 +8,8 @@ using namespace std::literals;
 using namespace boost::ut;
 using namespace Xbyak::util;
 
-static suite<"inline hook"> inline_hook_tests = [] {
+void register_inline_hook_tests() {
+suite<"inline hook"> inline_hook_tests = [] {
     "Function hooked multiple times"_test = [] {
         struct Target {
             SAFETYHOOK_NOINLINE static std::string fn(std::string name) { return "hello " + name; }
@@ -671,3 +672,4 @@ static suite<"inline hook"> inline_hook_tests = [] {
         expect(Target::fn(3) == 6_i);
     };
 };
+}

--- a/test/inline_hook.cpp
+++ b/test/inline_hook.cpp
@@ -257,7 +257,11 @@ TEST(InlineHook, FunctionWithShortConditionalBranchIsHooked) {
 #if SAFETYHOOK_OS_WINDOWS
     constexpr auto param = ecx;
 #elif SAFETYHOOK_OS_LINUX
+#if SAFETYHOOK_ARCH_X86_64
     constexpr auto param = edi;
+#elif SAFETYHOOK_ARCH_X86_32
+    auto param = dword[esp + 4];
+#endif
 #endif
 
     SCOPED_TRACE("JB");

--- a/test/inline_hook.cpp
+++ b/test/inline_hook.cpp
@@ -1,675 +1,738 @@
+#include <atomic>
+#include <chrono>
+#include <string>
+#include <string_view>
 #include <thread>
 
-#include <boost/ut.hpp>
+#include <gtest/gtest.h>
 #include <safetyhook.hpp>
 #include <xbyak/xbyak.h>
 
 using namespace std::literals;
-using namespace boost::ut;
 using namespace Xbyak::util;
 
-void register_inline_hook_tests() {
-suite<"inline hook"> inline_hook_tests = [] {
-    "Function hooked multiple times"_test = [] {
-        struct Target {
-            SAFETYHOOK_NOINLINE static std::string fn(std::string name) { return "hello " + name; }
-        };
-
-        expect(eq(Target::fn("world"), "hello world"sv));
-
-        // First hook.
-        static SafetyHookInline hook0;
-
-        struct Hook0 {
-            static std::string fn(std::string name) { return hook0.call<std::string>(name + " and bob"); }
-        };
-
-        auto hook0_result = SafetyHookInline::create(Target::fn, Hook0::fn);
-
-        expect(hook0_result.has_value());
-
-        hook0 = std::move(*hook0_result);
-
-        expect(eq(Target::fn("world"), "hello world and bob"sv));
-
-        // Second hook.
-        static SafetyHookInline hook1;
-
-        struct Hook1 {
-            static std::string fn(std::string name) { return hook1.call<std::string>(name + " and alice"); }
-        };
-
-        auto hook1_result = SafetyHookInline::create(Target::fn, Hook1::fn);
-
-        expect(hook1_result.has_value());
-
-        hook1 = std::move(*hook1_result);
-
-        expect(eq(Target::fn("world"), "hello world and alice and bob"sv));
-
-        // Third hook.
-        static SafetyHookInline hook2;
-
-        struct Hook2 {
-            static std::string fn(std::string name) { return hook2.call<std::string>(name + " and eve"); }
-        };
-
-        auto hook2_result = SafetyHookInline::create(Target::fn, Hook2::fn);
-
-        expect(hook2_result.has_value());
-
-        hook2 = std::move(*hook2_result);
-
-        expect(eq(Target::fn("world"), "hello world and eve and alice and bob"sv));
-
-        // Fourth hook.
-        static SafetyHookInline hook3;
-
-        struct Hook3 {
-            static std::string fn(std::string name) { return hook3.call<std::string>(name + " and carol"); }
-        };
-
-        auto hook3_result = SafetyHookInline::create(Target::fn, Hook3::fn);
-
-        expect(hook3_result.has_value());
-
-        hook3 = std::move(*hook3_result);
-
-        expect(eq(Target::fn("world"), "hello world and carol and eve and alice and bob"sv));
-
-        // Unhook.
-        hook3.reset();
-        hook2.reset();
-        hook1.reset();
-        hook0.reset();
+TEST(InlineHook, FunctionHookedMultipleTimes) {
+    struct Target {
+        SAFETYHOOK_NOINLINE static std::string fn(std::string name) { return "hello " + name; }
     };
 
-    "Function with multiple args hooked"_test = [] {
-        struct Target {
-            SAFETYHOOK_NOINLINE static int add(int x, int y) { return x + y; }
-        };
+    EXPECT_EQ(Target::fn("world"), "hello world"sv);
 
-        expect(Target::add(2, 3) == 5_i);
+    // First hook.
+    static SafetyHookInline hook0;
 
-        static SafetyHookInline add_hook;
-
-        struct AddHook {
-            static int add(int x, int y) { return add_hook.call<int>(x * 2, y * 2); }
-        };
-
-        auto add_hook_result = SafetyHookInline::create(Target::add, AddHook::add);
-
-        expect(add_hook_result.has_value());
-
-        add_hook = std::move(*add_hook_result);
-
-        expect(Target::add(3, 4) == 14_i);
-
-        add_hook.reset();
-
-        expect(Target::add(5, 6) == 11_i);
+    struct Hook0 {
+        static std::string fn(std::string name) { return hook0.call<std::string>(name + " and bob"); }
     };
+
+    auto hook0_result = SafetyHookInline::create(Target::fn, Hook0::fn);
+
+    ASSERT_TRUE(hook0_result.has_value());
+
+    hook0 = std::move(*hook0_result);
+
+    EXPECT_EQ(Target::fn("world"), "hello world and bob"sv);
+
+    // Second hook.
+    static SafetyHookInline hook1;
+
+    struct Hook1 {
+        static std::string fn(std::string name) { return hook1.call<std::string>(name + " and alice"); }
+    };
+
+    auto hook1_result = SafetyHookInline::create(Target::fn, Hook1::fn);
+
+    ASSERT_TRUE(hook1_result.has_value());
+
+    hook1 = std::move(*hook1_result);
+
+    EXPECT_EQ(Target::fn("world"), "hello world and alice and bob"sv);
+
+    // Third hook.
+    static SafetyHookInline hook2;
+
+    struct Hook2 {
+        static std::string fn(std::string name) { return hook2.call<std::string>(name + " and eve"); }
+    };
+
+    auto hook2_result = SafetyHookInline::create(Target::fn, Hook2::fn);
+
+    ASSERT_TRUE(hook2_result.has_value());
+
+    hook2 = std::move(*hook2_result);
+
+    EXPECT_EQ(Target::fn("world"), "hello world and eve and alice and bob"sv);
+
+    // Fourth hook.
+    static SafetyHookInline hook3;
+
+    struct Hook3 {
+        static std::string fn(std::string name) { return hook3.call<std::string>(name + " and carol"); }
+    };
+
+    auto hook3_result = SafetyHookInline::create(Target::fn, Hook3::fn);
+
+    ASSERT_TRUE(hook3_result.has_value());
+
+    hook3 = std::move(*hook3_result);
+
+    EXPECT_EQ(Target::fn("world"), "hello world and carol and eve and alice and bob"sv);
+
+    // Unhook.
+    hook3.reset();
+    hook2.reset();
+    hook1.reset();
+    hook0.reset();
+}
+
+TEST(InlineHook, FunctionWithMultipleArgsHooked) {
+    struct Target {
+        SAFETYHOOK_NOINLINE static int add(int x, int y) { return x + y; }
+    };
+
+    EXPECT_EQ(Target::add(2, 3), 5);
+
+    static SafetyHookInline add_hook;
+
+    struct AddHook {
+        static int add(int x, int y) { return add_hook.call<int>(x * 2, y * 2); }
+    };
+
+    auto add_hook_result = SafetyHookInline::create(Target::add, AddHook::add);
+
+    ASSERT_TRUE(add_hook_result.has_value());
+
+    add_hook = std::move(*add_hook_result);
+
+    EXPECT_EQ(Target::add(3, 4), 14);
+
+    add_hook.reset();
+
+    EXPECT_EQ(Target::add(5, 6), 11);
+}
 
 #if SAFETYHOOK_OS_WINDOWS
-    "Active function is hooked and unhooked"_test = [] {
-        static int count = 0;
-        static bool is_running = true;
+TEST(InlineHook, ActiveFunctionIsHookedAndUnhooked) {
+    static std::atomic<int> count = 0;
+    static std::atomic<bool> is_running = true;
+    static std::atomic<bool> pause_worker = false;
+    static std::atomic<bool> worker_paused = false;
 
-        struct Target {
-            SAFETYHOOK_NOINLINE static std::string say_hello(int times) { return "Hello #" + std::to_string(times); }
+    count.store(0, std::memory_order_relaxed);
+    is_running.store(true, std::memory_order_relaxed);
+    pause_worker.store(false, std::memory_order_relaxed);
+    worker_paused.store(false, std::memory_order_relaxed);
 
-            static void say_hello_infinitely() {
-                while (is_running) {
-                    say_hello(count++);
+    struct Target {
+        SAFETYHOOK_NOINLINE static std::string say_hello(int times) { return "Hello #" + std::to_string(times); }
+
+        static void say_hello_infinitely() {
+            while (is_running.load(std::memory_order_relaxed)) {
+                if (pause_worker.load(std::memory_order_acquire)) {
+                    worker_paused.store(true, std::memory_order_release);
+                    while (pause_worker.load(std::memory_order_acquire) && is_running.load(std::memory_order_relaxed)) {
+                        std::this_thread::yield();
+                    }
+                    worker_paused.store(false, std::memory_order_release);
+                    continue;
                 }
+
+                say_hello(count.fetch_add(1, std::memory_order_relaxed));
             }
-        };
-
-        std::thread t{Target::say_hello_infinitely};
-
-        std::this_thread::sleep_for(1s);
-
-        static SafetyHookInline hook;
-
-        struct Hook {
-            static std::string say_hello(int times [[maybe_unused]]) { return hook.call<std::string>(1337); }
-        };
-
-        auto hook_result = SafetyHookInline::create(Target::say_hello, Hook::say_hello);
-
-        expect(hook_result.has_value());
-
-        hook = std::move(*hook_result);
-
-        expect(eq(Target::say_hello(0), "Hello #1337"sv));
-
-        std::this_thread::sleep_for(1s);
-        hook.reset();
-
-        is_running = false;
-        t.join();
-
-        expect(eq(Target::say_hello(0), "Hello #0"sv));
-        expect(count > 0_i);
+        }
     };
+
+    std::thread t{Target::say_hello_infinitely};
+
+    std::this_thread::sleep_for(1s);
+
+    // This test hooks code in the same image as safetyhook, which makes trap_threads keep the page executable.
+    // Pause the worker while patching so the test does not race instruction writes. Hooking other images does not
+    // need this manual synchronization because thread trapping redirects execution during the patch window.
+    pause_worker.store(true, std::memory_order_release);
+
+    while (!worker_paused.load(std::memory_order_acquire)) {
+        std::this_thread::yield();
+    }
+
+    static SafetyHookInline hook;
+
+    struct Hook {
+        static std::string say_hello(int times [[maybe_unused]]) { return hook.call<std::string>(1337); }
+    };
+
+    const auto stop_worker = [&] {
+        is_running.store(false, std::memory_order_relaxed);
+        pause_worker.store(false, std::memory_order_release);
+        if (t.joinable()) {
+            t.join();
+        }
+    };
+
+    auto hook_result = SafetyHookInline::create(Target::say_hello, Hook::say_hello, SafetyHookInline::StartDisabled);
+
+    if (!hook_result.has_value()) {
+        stop_worker();
+        FAIL() << "Failed to create inline hook.";
+    }
+
+    hook = std::move(*hook_result);
+
+    if (!hook.enable().has_value()) {
+        stop_worker();
+        FAIL() << "Failed to enable inline hook.";
+    }
+    pause_worker.store(false, std::memory_order_release);
+
+    EXPECT_EQ(Target::say_hello(0), "Hello #1337"sv);
+
+    std::this_thread::sleep_for(1s);
+
+    pause_worker.store(true, std::memory_order_release);
+
+    while (!worker_paused.load(std::memory_order_acquire)) {
+        std::this_thread::yield();
+    }
+
+    hook.reset();
+
+    stop_worker();
+
+    EXPECT_EQ(Target::say_hello(0), "Hello #0"sv);
+    EXPECT_GT(count.load(std::memory_order_relaxed), 0);
+}
 #endif
 
-    "Function with short unconditional branch is hooked"_test = [] {
-        static SafetyHookInline hook;
+TEST(InlineHook, FunctionWithShortUnconditionalBranchIsHooked) {
+    static SafetyHookInline hook;
 
-        struct Hook {
-            static int SAFETYHOOK_FASTCALL fn() { return hook.fastcall<int>() + 42; };
-        };
+    struct Hook {
+        static int SAFETYHOOK_FASTCALL fn() { return hook.fastcall<int>() + 42; };
+    };
 
-        Xbyak::CodeGenerator cg{};
+    Xbyak::CodeGenerator cg{};
 
-        cg.jmp("@f");
+    cg.jmp("@f");
+    cg.mov(eax, 0);
+    cg.ret();
+    cg.nop(10, false);
+    cg.L("@@");
+    cg.mov(eax, 1);
+    cg.ret();
+    cg.nop(10, false);
+
+    const auto fn = cg.getCode<int(SAFETYHOOK_FASTCALL*)()>();
+
+    EXPECT_EQ(fn(), 1);
+
+    hook = safetyhook::create_inline(fn, Hook::fn);
+
+    EXPECT_EQ(fn(), 43);
+
+    hook.reset();
+
+    EXPECT_EQ(fn(), 1);
+}
+
+TEST(InlineHook, FunctionWithShortConditionalBranchIsHooked) {
+    static SafetyHookInline hook;
+
+    struct Hook {
+        static int SAFETYHOOK_FASTCALL fn(int x) { return hook.fastcall<int>(x) + 42; };
+    };
+
+    Xbyak::CodeGenerator cg{};
+    Xbyak::Label label{};
+    const auto finalize = [&cg, &label] {
         cg.mov(eax, 0);
         cg.ret();
         cg.nop(10, false);
-        cg.L("@@");
+        cg.L(label);
         cg.mov(eax, 1);
         cg.ret();
         cg.nop(10, false);
-
-        const auto fn = cg.getCode<int(SAFETYHOOK_FASTCALL*)()>();
-
-        expect(fn() == 1_i);
-
-        hook = safetyhook::create_inline(fn, Hook::fn);
-
-        expect(fn() == 43_i);
-
-        hook.reset();
-
-        expect(fn() == 1_i);
+        return cg.getCode<int(SAFETYHOOK_FASTCALL*)(int)>();
     };
-
-    "Function with short conditional branch is hooked"_test = [] {
-        static SafetyHookInline hook;
-
-        struct Hook {
-            static int SAFETYHOOK_FASTCALL fn(int x) { return hook.fastcall<int>(x) + 42; };
-        };
-
-        Xbyak::CodeGenerator cg{};
-        Xbyak::Label label{};
-        const auto finalize = [&cg, &label] {
-            cg.mov(eax, 0);
-            cg.ret();
-            cg.nop(10, false);
-            cg.L(label);
-            cg.mov(eax, 1);
-            cg.ret();
-            cg.nop(10, false);
-            return cg.getCode<int(SAFETYHOOK_FASTCALL*)(int)>();
-        };
 
 #if SAFETYHOOK_OS_WINDOWS
-        constexpr auto param = ecx;
+    constexpr auto param = ecx;
 #elif SAFETYHOOK_OS_LINUX
-        constexpr auto param = edi;
+    constexpr auto param = edi;
 #endif
 
-        "JB"_test = [&] {
-            cg.cmp(param, 8);
-            cg.jb(label);
-            const auto fn = finalize();
-
-            expect(fn(7) == 1_i);
-            expect(fn(8) == 0_i);
-            expect(fn(9) == 0_i);
-
-            hook = safetyhook::create_inline(fn, Hook::fn);
-
-            expect(fn(7) == 43_i);
-            expect(fn(8) == 42_i);
-            expect(fn(9) == 42_i);
-
-            hook.reset();
-
-            expect(fn(7) == 1_i);
-            expect(fn(8) == 0_i);
-            expect(fn(9) == 0_i);
-
-            cg.reset();
-        };
-
-        "JBE"_test = [&] {
-            cg.cmp(param, 8);
-            cg.jbe(label);
-            const auto fn = finalize();
-
-            expect(fn(7) == 1_i);
-            expect(fn(8) == 1_i);
-            expect(fn(9) == 0_i);
-
-            hook = safetyhook::create_inline(fn, Hook::fn);
-
-            expect(fn(7) == 43_i);
-            expect(fn(8) == 43_i);
-            expect(fn(9) == 42_i);
-
-            hook.reset();
-
-            expect(fn(7) == 1_i);
-            expect(fn(8) == 1_i);
-            expect(fn(9) == 0_i);
-
-            cg.reset();
-        };
-
-        "JL"_test = [&] {
-            cg.cmp(param, 8);
-            cg.jl(label);
-            const auto fn = finalize();
-
-            expect(fn(7) == 1_i);
-            expect(fn(8) == 0_i);
-            expect(fn(9) == 0_i);
-
-            hook = safetyhook::create_inline(fn, Hook::fn);
-
-            expect(fn(7) == 43_i);
-            expect(fn(8) == 42_i);
-            expect(fn(9) == 42_i);
-
-            hook.reset();
-
-            expect(fn(7) == 1_i);
-            expect(fn(8) == 0_i);
-            expect(fn(9) == 0_i);
-
-            cg.reset();
-        };
-
-        "JLE"_test = [&] {
-            cg.cmp(param, 8);
-            cg.jle(label);
-            const auto fn = finalize();
-
-            expect(fn(7) == 1_i);
-            expect(fn(8) == 1_i);
-            expect(fn(9) == 0_i);
-
-            hook = safetyhook::create_inline(fn, Hook::fn);
-
-            expect(fn(7) == 43_i);
-            expect(fn(8) == 43_i);
-            expect(fn(9) == 42_i);
-
-            hook.reset();
-
-            expect(fn(7) == 1_i);
-            expect(fn(8) == 1_i);
-            expect(fn(9) == 0_i);
-
-            cg.reset();
-        };
-
-        "JNB"_test = [&] {
-            cg.cmp(param, 8);
-            cg.jnb(label);
-            const auto fn = finalize();
-
-            expect(fn(7) == 0_i);
-            expect(fn(8) == 1_i);
-            expect(fn(9) == 1_i);
-
-            hook = safetyhook::create_inline(fn, Hook::fn);
-
-            expect(fn(7) == 42_i);
-            expect(fn(8) == 43_i);
-            expect(fn(9) == 43_i);
-
-            hook.reset();
-
-            expect(fn(7) == 0_i);
-            expect(fn(8) == 1_i);
-            expect(fn(9) == 1_i);
-
-            cg.reset();
-        };
-
-        "JNBE"_test = [&] {
-            cg.cmp(param, 8);
-            cg.jnbe(label);
-            const auto fn = finalize();
-
-            expect(fn(7) == 0_i);
-            expect(fn(8) == 0_i);
-            expect(fn(9) == 1_i);
-
-            hook = safetyhook::create_inline(fn, Hook::fn);
-
-            expect(fn(7) == 42_i);
-            expect(fn(8) == 42_i);
-            expect(fn(9) == 43_i);
-
-            hook.reset();
-
-            expect(fn(7) == 0_i);
-            expect(fn(8) == 0_i);
-            expect(fn(9) == 1_i);
-
-            cg.reset();
-        };
-
-        "JNL"_test = [&] {
-            cg.cmp(param, 8);
-            cg.jnl(label);
-            const auto fn = finalize();
-
-            expect(fn(7) == 0_i);
-            expect(fn(8) == 1_i);
-            expect(fn(9) == 1_i);
-
-            hook = safetyhook::create_inline(fn, Hook::fn);
-
-            expect(fn(7) == 42_i);
-            expect(fn(8) == 43_i);
-            expect(fn(9) == 43_i);
-
-            hook.reset();
-
-            expect(fn(7) == 0_i);
-            expect(fn(8) == 1_i);
-            expect(fn(9) == 1_i);
-
-            cg.reset();
-        };
-
-        "JNLE"_test = [&] {
-            cg.cmp(param, 8);
-            cg.jnle(label);
-            const auto fn = finalize();
-
-            expect(fn(7) == 0_i);
-            expect(fn(8) == 0_i);
-            expect(fn(9) == 1_i);
-
-            hook = safetyhook::create_inline(fn, Hook::fn);
-
-            expect(fn(7) == 42_i);
-            expect(fn(8) == 42_i);
-            expect(fn(9) == 43_i);
-
-            hook.reset();
-
-            expect(fn(7) == 0_i);
-            expect(fn(8) == 0_i);
-            expect(fn(9) == 1_i);
-
-            cg.reset();
-        };
-
-        "JNO"_test = [&] {
-            cg.cmp(param, 8);
-            cg.jno(label);
-            const auto fn = finalize();
-
-            expect(fn(7) == 1_i);
-            expect(fn(8) == 1_i);
-            expect(fn(9) == 1_i);
-
-            hook = safetyhook::create_inline(fn, Hook::fn);
-
-            expect(fn(7) == 43_i);
-            expect(fn(8) == 43_i);
-            expect(fn(9) == 43_i);
-
-            hook.reset();
-
-            expect(fn(7) == 1_i);
-            expect(fn(8) == 1_i);
-            expect(fn(9) == 1_i);
-
-            cg.reset();
-        };
-
-        "JNP"_test = [&] {
-            cg.cmp(param, 8);
-            cg.jnp(label);
-            const auto fn = finalize();
-
-            expect(fn(7) == 0_i);
-            expect(fn(8) == 0_i);
-            expect(fn(9) == 1_i);
-
-            hook = safetyhook::create_inline(fn, Hook::fn);
-
-            expect(fn(7) == 42_i);
-            expect(fn(8) == 42_i);
-            expect(fn(9) == 43_i);
-
-            hook.reset();
-
-            expect(fn(7) == 0_i);
-            expect(fn(8) == 0_i);
-            expect(fn(9) == 1_i);
-
-            cg.reset();
-        };
-
-        "JNS"_test = [&] {
-            cg.cmp(param, 8);
-            cg.jns(label);
-            const auto fn = finalize();
-
-            expect(fn(7) == 0_i);
-            expect(fn(8) == 1_i);
-            expect(fn(9) == 1_i);
-
-            hook = safetyhook::create_inline(fn, Hook::fn);
-
-            expect(fn(7) == 42_i);
-            expect(fn(8) == 43_i);
-            expect(fn(9) == 43_i);
-
-            hook.reset();
-
-            expect(fn(7) == 0_i);
-            expect(fn(8) == 1_i);
-            expect(fn(9) == 1_i);
-
-            cg.reset();
-        };
-
-        "JNZ"_test = [&] {
-            cg.cmp(param, 8);
-            cg.jnz(label);
-            const auto fn = finalize();
-
-            expect(fn(7) == 1_i);
-            expect(fn(8) == 0_i);
-            expect(fn(9) == 1_i);
-
-            hook = safetyhook::create_inline(fn, Hook::fn);
-
-            expect(fn(7) == 43_i);
-            expect(fn(8) == 42_i);
-            expect(fn(9) == 43_i);
-
-            hook.reset();
-
-            expect(fn(7) == 1_i);
-            expect(fn(8) == 0_i);
-            expect(fn(9) == 1_i);
-
-            cg.reset();
-        };
-
-        "JO"_test = [&] {
-            cg.cmp(param, 8);
-            cg.jo(label);
-            const auto fn = finalize();
-
-            expect(fn(7) == 0_i);
-            expect(fn(8) == 0_i);
-            expect(fn(9) == 0_i);
-
-            hook = safetyhook::create_inline(fn, Hook::fn);
-
-            expect(fn(7) == 42_i);
-            expect(fn(8) == 42_i);
-            expect(fn(9) == 42_i);
-
-            hook.reset();
-
-            expect(fn(7) == 0_i);
-            expect(fn(8) == 0_i);
-            expect(fn(9) == 0_i);
-
-            cg.reset();
-        };
-
-        "JP"_test = [&] {
-            cg.cmp(param, 8);
-            cg.jp(label);
-            const auto fn = finalize();
-
-            expect(fn(7) == 1_i);
-            expect(fn(8) == 1_i);
-            expect(fn(9) == 0_i);
-
-            hook = safetyhook::create_inline(fn, Hook::fn);
-
-            expect(fn(7) == 43_i);
-            expect(fn(8) == 43_i);
-            expect(fn(9) == 42_i);
-
-            hook.reset();
-
-            expect(fn(7) == 1_i);
-            expect(fn(8) == 1_i);
-            expect(fn(9) == 0_i);
-
-            cg.reset();
-        };
-
-        "JS"_test = [&] {
-            cg.cmp(param, 8);
-            cg.js(label);
-            const auto fn = finalize();
-
-            expect(fn(7) == 1_i);
-            expect(fn(8) == 0_i);
-            expect(fn(9) == 0_i);
-
-            hook = safetyhook::create_inline(fn, Hook::fn);
-
-            expect(fn(7) == 43_i);
-            expect(fn(8) == 42_i);
-            expect(fn(9) == 42_i);
-
-            hook.reset();
-
-            expect(fn(7) == 1_i);
-            expect(fn(8) == 0_i);
-            expect(fn(9) == 0_i);
-
-            cg.reset();
-        };
-
-        "JZ"_test = [&] {
-            cg.cmp(param, 8);
-            cg.jz(label);
-            const auto fn = finalize();
-
-            expect(fn(7) == 0_i);
-            expect(fn(8) == 1_i);
-            expect(fn(9) == 0_i);
-
-            hook = safetyhook::create_inline(fn, Hook::fn);
-
-            expect(fn(7) == 42_i);
-            expect(fn(8) == 43_i);
-            expect(fn(9) == 42_i);
-
-            hook.reset();
-
-            expect(fn(7) == 0_i);
-            expect(fn(8) == 1_i);
-            expect(fn(9) == 0_i);
-
-            cg.reset();
-        };
-    };
-
-    "Function with short jump inside trampoline"_test = [] {
-        Xbyak::CodeGenerator cg{};
-
-        cg.jmp("@f");
-        cg.ret();
-        cg.L("@@");
-        cg.mov(eax, 42);
-        cg.ret();
-        cg.nop(10, false);
-
-        const auto fn = cg.getCode<int (*)()>();
-
-        expect(fn() == 42_i);
-
-        static SafetyHookInline hook;
-
-        struct Hook {
-            static int fn() { return hook.call<int>() + 1; }
-        };
+    SCOPED_TRACE("JB");
+    {
+        cg.cmp(param, 8);
+        cg.jb(label);
+        const auto fn = finalize();
+
+        EXPECT_EQ(fn(7), 1);
+        EXPECT_EQ(fn(8), 0);
+        EXPECT_EQ(fn(9), 0);
 
         hook = safetyhook::create_inline(fn, Hook::fn);
 
-        expect(fn() == 43_i);
+        EXPECT_EQ(fn(7), 43);
+        EXPECT_EQ(fn(8), 42);
+        EXPECT_EQ(fn(9), 42);
 
         hook.reset();
 
-        expect(fn() == 42_i);
-    };
+        EXPECT_EQ(fn(7), 1);
+        EXPECT_EQ(fn(8), 0);
+        EXPECT_EQ(fn(9), 0);
 
-    "Function hook can be enable and disabled"_test = [] {
-        struct Target {
-            SAFETYHOOK_NOINLINE static int fn(int a) {
-                volatile int b = a;
-                return b * 2;
-            }
-        };
+        cg.reset();
+    }
 
-        expect(Target::fn(1) == 2_i);
-        expect(Target::fn(2) == 4_i);
-        expect(Target::fn(3) == 6_i);
+    SCOPED_TRACE("JBE");
+    {
+        cg.cmp(param, 8);
+        cg.jbe(label);
+        const auto fn = finalize();
 
-        static SafetyHookInline hook;
+        EXPECT_EQ(fn(7), 1);
+        EXPECT_EQ(fn(8), 1);
+        EXPECT_EQ(fn(9), 0);
 
-        struct Hook {
-            static int fn(int a) { return hook.call<int>(a + 1); }
-        };
+        hook = safetyhook::create_inline(fn, Hook::fn);
 
-        auto hook0_result = SafetyHookInline::create(Target::fn, Hook::fn, SafetyHookInline::StartDisabled);
-
-        expect(hook0_result.has_value());
-
-        hook = std::move(*hook0_result);
-
-        expect(Target::fn(1) == 2_i);
-        expect(Target::fn(2) == 4_i);
-        expect(Target::fn(3) == 6_i);
-
-        expect(hook.enable().has_value());
-
-        expect(Target::fn(1) == 4_i);
-        expect(Target::fn(2) == 6_i);
-        expect(Target::fn(3) == 8_i);
-
-        expect(hook.disable().has_value());
-
-        expect(Target::fn(1) == 2_i);
-        expect(Target::fn(2) == 4_i);
-        expect(Target::fn(3) == 6_i);
+        EXPECT_EQ(fn(7), 43);
+        EXPECT_EQ(fn(8), 43);
+        EXPECT_EQ(fn(9), 42);
 
         hook.reset();
 
-        expect(Target::fn(1) == 2_i);
-        expect(Target::fn(2) == 4_i);
-        expect(Target::fn(3) == 6_i);
+        EXPECT_EQ(fn(7), 1);
+        EXPECT_EQ(fn(8), 1);
+        EXPECT_EQ(fn(9), 0);
+
+        cg.reset();
+    }
+
+    SCOPED_TRACE("JL");
+    {
+        cg.cmp(param, 8);
+        cg.jl(label);
+        const auto fn = finalize();
+
+        EXPECT_EQ(fn(7), 1);
+        EXPECT_EQ(fn(8), 0);
+        EXPECT_EQ(fn(9), 0);
+
+        hook = safetyhook::create_inline(fn, Hook::fn);
+
+        EXPECT_EQ(fn(7), 43);
+        EXPECT_EQ(fn(8), 42);
+        EXPECT_EQ(fn(9), 42);
+
+        hook.reset();
+
+        EXPECT_EQ(fn(7), 1);
+        EXPECT_EQ(fn(8), 0);
+        EXPECT_EQ(fn(9), 0);
+
+        cg.reset();
+    }
+
+    SCOPED_TRACE("JLE");
+    {
+        cg.cmp(param, 8);
+        cg.jle(label);
+        const auto fn = finalize();
+
+        EXPECT_EQ(fn(7), 1);
+        EXPECT_EQ(fn(8), 1);
+        EXPECT_EQ(fn(9), 0);
+
+        hook = safetyhook::create_inline(fn, Hook::fn);
+
+        EXPECT_EQ(fn(7), 43);
+        EXPECT_EQ(fn(8), 43);
+        EXPECT_EQ(fn(9), 42);
+
+        hook.reset();
+
+        EXPECT_EQ(fn(7), 1);
+        EXPECT_EQ(fn(8), 1);
+        EXPECT_EQ(fn(9), 0);
+
+        cg.reset();
+    }
+
+    SCOPED_TRACE("JNB");
+    {
+        cg.cmp(param, 8);
+        cg.jnb(label);
+        const auto fn = finalize();
+
+        EXPECT_EQ(fn(7), 0);
+        EXPECT_EQ(fn(8), 1);
+        EXPECT_EQ(fn(9), 1);
+
+        hook = safetyhook::create_inline(fn, Hook::fn);
+
+        EXPECT_EQ(fn(7), 42);
+        EXPECT_EQ(fn(8), 43);
+        EXPECT_EQ(fn(9), 43);
+
+        hook.reset();
+
+        EXPECT_EQ(fn(7), 0);
+        EXPECT_EQ(fn(8), 1);
+        EXPECT_EQ(fn(9), 1);
+
+        cg.reset();
+    }
+
+    SCOPED_TRACE("JNBE");
+    {
+        cg.cmp(param, 8);
+        cg.jnbe(label);
+        const auto fn = finalize();
+
+        EXPECT_EQ(fn(7), 0);
+        EXPECT_EQ(fn(8), 0);
+        EXPECT_EQ(fn(9), 1);
+
+        hook = safetyhook::create_inline(fn, Hook::fn);
+
+        EXPECT_EQ(fn(7), 42);
+        EXPECT_EQ(fn(8), 42);
+        EXPECT_EQ(fn(9), 43);
+
+        hook.reset();
+
+        EXPECT_EQ(fn(7), 0);
+        EXPECT_EQ(fn(8), 0);
+        EXPECT_EQ(fn(9), 1);
+
+        cg.reset();
+    }
+
+    SCOPED_TRACE("JNL");
+    {
+        cg.cmp(param, 8);
+        cg.jnl(label);
+        const auto fn = finalize();
+
+        EXPECT_EQ(fn(7), 0);
+        EXPECT_EQ(fn(8), 1);
+        EXPECT_EQ(fn(9), 1);
+
+        hook = safetyhook::create_inline(fn, Hook::fn);
+
+        EXPECT_EQ(fn(7), 42);
+        EXPECT_EQ(fn(8), 43);
+        EXPECT_EQ(fn(9), 43);
+
+        hook.reset();
+
+        EXPECT_EQ(fn(7), 0);
+        EXPECT_EQ(fn(8), 1);
+        EXPECT_EQ(fn(9), 1);
+
+        cg.reset();
+    }
+
+    SCOPED_TRACE("JNLE");
+    {
+        cg.cmp(param, 8);
+        cg.jnle(label);
+        const auto fn = finalize();
+
+        EXPECT_EQ(fn(7), 0);
+        EXPECT_EQ(fn(8), 0);
+        EXPECT_EQ(fn(9), 1);
+
+        hook = safetyhook::create_inline(fn, Hook::fn);
+
+        EXPECT_EQ(fn(7), 42);
+        EXPECT_EQ(fn(8), 42);
+        EXPECT_EQ(fn(9), 43);
+
+        hook.reset();
+
+        EXPECT_EQ(fn(7), 0);
+        EXPECT_EQ(fn(8), 0);
+        EXPECT_EQ(fn(9), 1);
+
+        cg.reset();
+    }
+
+    SCOPED_TRACE("JNO");
+    {
+        cg.cmp(param, 8);
+        cg.jno(label);
+        const auto fn = finalize();
+
+        EXPECT_EQ(fn(7), 1);
+        EXPECT_EQ(fn(8), 1);
+        EXPECT_EQ(fn(9), 1);
+
+        hook = safetyhook::create_inline(fn, Hook::fn);
+
+        EXPECT_EQ(fn(7), 43);
+        EXPECT_EQ(fn(8), 43);
+        EXPECT_EQ(fn(9), 43);
+
+        hook.reset();
+
+        EXPECT_EQ(fn(7), 1);
+        EXPECT_EQ(fn(8), 1);
+        EXPECT_EQ(fn(9), 1);
+
+        cg.reset();
+    }
+
+    SCOPED_TRACE("JNP");
+    {
+        cg.cmp(param, 8);
+        cg.jnp(label);
+        const auto fn = finalize();
+
+        EXPECT_EQ(fn(7), 0);
+        EXPECT_EQ(fn(8), 0);
+        EXPECT_EQ(fn(9), 1);
+
+        hook = safetyhook::create_inline(fn, Hook::fn);
+
+        EXPECT_EQ(fn(7), 42);
+        EXPECT_EQ(fn(8), 42);
+        EXPECT_EQ(fn(9), 43);
+
+        hook.reset();
+
+        EXPECT_EQ(fn(7), 0);
+        EXPECT_EQ(fn(8), 0);
+        EXPECT_EQ(fn(9), 1);
+
+        cg.reset();
+    }
+
+    SCOPED_TRACE("JNS");
+    {
+        cg.cmp(param, 8);
+        cg.jns(label);
+        const auto fn = finalize();
+
+        EXPECT_EQ(fn(7), 0);
+        EXPECT_EQ(fn(8), 1);
+        EXPECT_EQ(fn(9), 1);
+
+        hook = safetyhook::create_inline(fn, Hook::fn);
+
+        EXPECT_EQ(fn(7), 42);
+        EXPECT_EQ(fn(8), 43);
+        EXPECT_EQ(fn(9), 43);
+
+        hook.reset();
+
+        EXPECT_EQ(fn(7), 0);
+        EXPECT_EQ(fn(8), 1);
+        EXPECT_EQ(fn(9), 1);
+
+        cg.reset();
+    }
+
+    SCOPED_TRACE("JNZ");
+    {
+        cg.cmp(param, 8);
+        cg.jnz(label);
+        const auto fn = finalize();
+
+        EXPECT_EQ(fn(7), 1);
+        EXPECT_EQ(fn(8), 0);
+        EXPECT_EQ(fn(9), 1);
+
+        hook = safetyhook::create_inline(fn, Hook::fn);
+
+        EXPECT_EQ(fn(7), 43);
+        EXPECT_EQ(fn(8), 42);
+        EXPECT_EQ(fn(9), 43);
+
+        hook.reset();
+
+        EXPECT_EQ(fn(7), 1);
+        EXPECT_EQ(fn(8), 0);
+        EXPECT_EQ(fn(9), 1);
+
+        cg.reset();
+    }
+
+    SCOPED_TRACE("JO");
+    {
+        cg.cmp(param, 8);
+        cg.jo(label);
+        const auto fn = finalize();
+
+        EXPECT_EQ(fn(7), 0);
+        EXPECT_EQ(fn(8), 0);
+        EXPECT_EQ(fn(9), 0);
+
+        hook = safetyhook::create_inline(fn, Hook::fn);
+
+        EXPECT_EQ(fn(7), 42);
+        EXPECT_EQ(fn(8), 42);
+        EXPECT_EQ(fn(9), 42);
+
+        hook.reset();
+
+        EXPECT_EQ(fn(7), 0);
+        EXPECT_EQ(fn(8), 0);
+        EXPECT_EQ(fn(9), 0);
+
+        cg.reset();
+    }
+
+    SCOPED_TRACE("JP");
+    {
+        cg.cmp(param, 8);
+        cg.jp(label);
+        const auto fn = finalize();
+
+        EXPECT_EQ(fn(7), 1);
+        EXPECT_EQ(fn(8), 1);
+        EXPECT_EQ(fn(9), 0);
+
+        hook = safetyhook::create_inline(fn, Hook::fn);
+
+        EXPECT_EQ(fn(7), 43);
+        EXPECT_EQ(fn(8), 43);
+        EXPECT_EQ(fn(9), 42);
+
+        hook.reset();
+
+        EXPECT_EQ(fn(7), 1);
+        EXPECT_EQ(fn(8), 1);
+        EXPECT_EQ(fn(9), 0);
+
+        cg.reset();
+    }
+
+    SCOPED_TRACE("JS");
+    {
+        cg.cmp(param, 8);
+        cg.js(label);
+        const auto fn = finalize();
+
+        EXPECT_EQ(fn(7), 1);
+        EXPECT_EQ(fn(8), 0);
+        EXPECT_EQ(fn(9), 0);
+
+        hook = safetyhook::create_inline(fn, Hook::fn);
+
+        EXPECT_EQ(fn(7), 43);
+        EXPECT_EQ(fn(8), 42);
+        EXPECT_EQ(fn(9), 42);
+
+        hook.reset();
+
+        EXPECT_EQ(fn(7), 1);
+        EXPECT_EQ(fn(8), 0);
+        EXPECT_EQ(fn(9), 0);
+
+        cg.reset();
+    }
+
+    SCOPED_TRACE("JZ");
+    {
+        cg.cmp(param, 8);
+        cg.jz(label);
+        const auto fn = finalize();
+
+        EXPECT_EQ(fn(7), 0);
+        EXPECT_EQ(fn(8), 1);
+        EXPECT_EQ(fn(9), 0);
+
+        hook = safetyhook::create_inline(fn, Hook::fn);
+
+        EXPECT_EQ(fn(7), 42);
+        EXPECT_EQ(fn(8), 43);
+        EXPECT_EQ(fn(9), 42);
+
+        hook.reset();
+
+        EXPECT_EQ(fn(7), 0);
+        EXPECT_EQ(fn(8), 1);
+        EXPECT_EQ(fn(9), 0);
+
+        cg.reset();
+    }
+}
+
+TEST(InlineHook, FunctionWithShortJumpInsideTrampoline) {
+    Xbyak::CodeGenerator cg{};
+
+    cg.jmp("@f");
+    cg.ret();
+    cg.L("@@");
+    cg.mov(eax, 42);
+    cg.ret();
+    cg.nop(10, false);
+
+    const auto fn = cg.getCode<int (*)()>();
+
+    EXPECT_EQ(fn(), 42);
+
+    static SafetyHookInline hook;
+
+    struct Hook {
+        static int fn() { return hook.call<int>() + 1; }
     };
-};
+
+    hook = safetyhook::create_inline(fn, Hook::fn);
+
+    EXPECT_EQ(fn(), 43);
+
+    hook.reset();
+
+    EXPECT_EQ(fn(), 42);
+}
+
+TEST(InlineHook, FunctionHookCanBeEnableAndDisabled) {
+    struct Target {
+        SAFETYHOOK_NOINLINE static int fn(int a) {
+            volatile int b = a;
+            return b * 2;
+        }
+    };
+
+    EXPECT_EQ(Target::fn(1), 2);
+    EXPECT_EQ(Target::fn(2), 4);
+    EXPECT_EQ(Target::fn(3), 6);
+
+    static SafetyHookInline hook;
+
+    struct Hook {
+        static int fn(int a) { return hook.call<int>(a + 1); }
+    };
+
+    auto hook0_result = SafetyHookInline::create(Target::fn, Hook::fn, SafetyHookInline::StartDisabled);
+
+    ASSERT_TRUE(hook0_result.has_value());
+
+    hook = std::move(*hook0_result);
+
+    EXPECT_EQ(Target::fn(1), 2);
+    EXPECT_EQ(Target::fn(2), 4);
+    EXPECT_EQ(Target::fn(3), 6);
+
+    ASSERT_TRUE(hook.enable().has_value());
+
+    EXPECT_EQ(Target::fn(1), 4);
+    EXPECT_EQ(Target::fn(2), 6);
+    EXPECT_EQ(Target::fn(3), 8);
+
+    ASSERT_TRUE(hook.disable().has_value());
+
+    EXPECT_EQ(Target::fn(1), 2);
+    EXPECT_EQ(Target::fn(2), 4);
+    EXPECT_EQ(Target::fn(3), 6);
+
+    hook.reset();
+
+    EXPECT_EQ(Target::fn(1), 2);
+    EXPECT_EQ(Target::fn(2), 4);
+    EXPECT_EQ(Target::fn(3), 6);
 }

--- a/test/inline_hook.x86_64.cpp
+++ b/test/inline_hook.x86_64.cpp
@@ -16,7 +16,8 @@ void asciiz(Xbyak::CodeGenerator& cg, const char* str) {
     cg.db(0);
 }
 
-static suite<"inline hook (x64)"> inline_hook_x64_tests = [] {
+void register_inline_hook_x64_tests() {
+suite<"inline hook (x64)"> inline_hook_x64_tests = [] {
     "Function with RIP-relative operand is hooked"_test = [] {
         Xbyak::CodeGenerator cg{};
         Xbyak::Label str_label{};
@@ -101,5 +102,8 @@ static suite<"inline hook (x64)"> inline_hook_x64_tests = [] {
         expect(fn(4) == 16_i);
     };
 };
+}
 
+#else
+void register_inline_hook_x64_tests() {}
 #endif

--- a/test/inline_hook.x86_64.cpp
+++ b/test/inline_hook.x86_64.cpp
@@ -58,17 +58,18 @@ static suite<"inline hook (x64)"> inline_hook_x64_tests = [] {
         Xbyak::CodeGenerator cg{5'000'000'000}; // 5 GB
         Xbyak::Label start{};
 
-#if SAFETYHOOK_OS_WINDOWS
-        constexpr auto param = ecx;
-#elif SAFETYHOOK_OS_LINUX
-        constexpr auto param = edi;
-#endif
-
         cg.nop(2'500'000'000, false); // 2.5 GB
         cg.L(start);
-        cg.mov(dword[rsp + 8], param);
+
+#if SAFETYHOOK_OS_WINDOWS
+        cg.mov(dword[rsp + 8], ecx);
         cg.mov(eax, dword[rsp + 8]);
         cg.imul(eax, dword[rsp + 8]);
+#elif SAFETYHOOK_OS_LINUX
+        cg.mov(eax, edi);
+        cg.imul(eax, edi);
+#endif
+
         cg.ret();
 
         auto fn = reinterpret_cast<int (*)(int)>(const_cast<uint8_t*>(start.getAddress()));

--- a/test/inline_hook.x86_64.cpp
+++ b/test/inline_hook.x86_64.cpp
@@ -36,7 +36,7 @@ TEST(InlineHookX64, FunctionWithRIPRelativeOperandIsHooked) {
 
     EXPECT_EQ(fn(), "Hello"sv);
 
-    static SafetyHookInline hook;
+    SafetyHookInline hook;
 
     struct Hook {
         static const char* fn() { return "Hello, world!"; }
@@ -79,10 +79,12 @@ TEST(InlineHookX64, FunctionWithNoNearbyMemoryIsHooked) {
     EXPECT_EQ(fn(3), 9);
     EXPECT_EQ(fn(4), 16);
 
-    static SafetyHookInline hook;
+    static SafetyHookInline* hook_ptr{};
+    SafetyHookInline hook;
+    hook_ptr = &hook;
 
     struct Hook {
-        static int fn(int a) { return hook.call<int>(a) * a; }
+        static int fn(int a) { return hook_ptr->call<int>(a) * a; }
     };
 
     auto hook_result = SafetyHookInline::create(fn, Hook::fn);

--- a/test/inline_hook.x86_64.cpp
+++ b/test/inline_hook.x86_64.cpp
@@ -1,11 +1,13 @@
-#include <boost/ut.hpp>
+#include <cstdint>
+#include <string_view>
+
+#include <gtest/gtest.h>
 #include <safetyhook.hpp>
 #include <xbyak/xbyak.h>
 
 #if SAFETYHOOK_ARCH_X86_64
 
 using namespace std::literals;
-using namespace boost::ut;
 using namespace Xbyak::util;
 
 void asciiz(Xbyak::CodeGenerator& cg, const char* str) {
@@ -16,94 +18,88 @@ void asciiz(Xbyak::CodeGenerator& cg, const char* str) {
     cg.db(0);
 }
 
-void register_inline_hook_x64_tests() {
-suite<"inline hook (x64)"> inline_hook_x64_tests = [] {
-    "Function with RIP-relative operand is hooked"_test = [] {
-        Xbyak::CodeGenerator cg{};
-        Xbyak::Label str_label{};
+TEST(InlineHookX64, FunctionWithRIPRelativeOperandIsHooked) {
+    Xbyak::CodeGenerator cg{};
+    Xbyak::Label str_label{};
 
-        cg.lea(rax, ptr[rip + str_label]);
-        cg.ret();
+    cg.lea(rax, ptr[rip + str_label]);
+    cg.ret();
 
-        for (auto i = 0; i < 10; ++i) {
-            cg.nop(10, false);
-        }
+    for (auto i = 0; i < 10; ++i) {
+        cg.nop(10, false);
+    }
 
-        cg.L(str_label);
-        asciiz(cg, "Hello");
+    cg.L(str_label);
+    asciiz(cg, "Hello");
 
-        const auto fn = cg.getCode<const char* (*)()>();
+    const auto fn = cg.getCode<const char* (*)()>();
 
-        expect(eq(fn(), "Hello"sv));
+    EXPECT_EQ(fn(), "Hello"sv);
 
-        static SafetyHookInline hook;
+    static SafetyHookInline hook;
 
-        struct Hook {
-            static const char* fn() { return "Hello, world!"; }
-        };
-
-        auto hook_result = SafetyHookInline::create(fn, Hook::fn);
-
-        expect(hook_result.has_value());
-
-        hook = std::move(*hook_result);
-
-        expect(eq(fn(), "Hello, world!"sv));
-
-        hook.reset();
-
-        expect(eq(fn(), "Hello"sv));
+    struct Hook {
+        static const char* fn() { return "Hello, world!"; }
     };
 
-    "Function with no nearby memory is hooked"_test = [] {
-        Xbyak::CodeGenerator cg{5'000'000'000}; // 5 GB
-        Xbyak::Label start{};
+    auto hook_result = SafetyHookInline::create(fn, Hook::fn);
 
-        cg.nop(2'500'000'000, false); // 2.5 GB
-        cg.L(start);
+    ASSERT_TRUE(hook_result.has_value());
 
-#if SAFETYHOOK_OS_WINDOWS
-        cg.mov(dword[rsp + 8], ecx);
-        cg.mov(eax, dword[rsp + 8]);
-        cg.imul(eax, dword[rsp + 8]);
-#elif SAFETYHOOK_OS_LINUX
-        cg.mov(eax, edi);
-        cg.imul(eax, edi);
-#endif
+    hook = std::move(*hook_result);
 
-        cg.ret();
+    EXPECT_EQ(fn(), "Hello, world!"sv);
 
-        auto fn = reinterpret_cast<int (*)(int)>(const_cast<uint8_t*>(start.getAddress()));
+    hook.reset();
 
-        expect(fn(2) == 4_i);
-        expect(fn(3) == 9_i);
-        expect(fn(4) == 16_i);
-
-        static SafetyHookInline hook;
-
-        struct Hook {
-            static int fn(int a) { return hook.call<int>(a) * a; }
-        };
-
-        auto hook_result = SafetyHookInline::create(fn, Hook::fn);
-
-        expect(hook_result.has_value());
-
-        hook = std::move(*hook_result);
-
-        expect(fn(2) == 8_i);
-        expect(fn(3) == 27_i);
-        expect(fn(4) == 64_i);
-
-        hook.reset();
-
-        expect(fn(2) == 4_i);
-        expect(fn(3) == 9_i);
-        expect(fn(4) == 16_i);
-    };
-};
+    EXPECT_EQ(fn(), "Hello"sv);
 }
 
-#else
-void register_inline_hook_x64_tests() {}
+TEST(InlineHookX64, FunctionWithNoNearbyMemoryIsHooked) {
+    Xbyak::CodeGenerator cg{5'000'000'000}; // 5 GB
+    Xbyak::Label start{};
+
+    cg.nop(2'500'000'000, false); // 2.5 GB
+    cg.L(start);
+
+#if SAFETYHOOK_OS_WINDOWS
+    cg.mov(dword[rsp + 8], ecx);
+    cg.mov(eax, dword[rsp + 8]);
+    cg.imul(eax, dword[rsp + 8]);
+#elif SAFETYHOOK_OS_LINUX
+    cg.mov(eax, edi);
+    cg.imul(eax, edi);
+#endif
+
+    cg.ret();
+
+    auto fn = reinterpret_cast<int (*)(int)>(const_cast<uint8_t*>(start.getAddress()));
+
+    EXPECT_EQ(fn(2), 4);
+    EXPECT_EQ(fn(3), 9);
+    EXPECT_EQ(fn(4), 16);
+
+    static SafetyHookInline hook;
+
+    struct Hook {
+        static int fn(int a) { return hook.call<int>(a) * a; }
+    };
+
+    auto hook_result = SafetyHookInline::create(fn, Hook::fn);
+
+    ASSERT_TRUE(hook_result.has_value());
+
+    hook = std::move(*hook_result);
+
+    EXPECT_EQ(fn(2), 8);
+    EXPECT_EQ(fn(3), 27);
+    EXPECT_EQ(fn(4), 64);
+
+    hook.reset();
+
+    EXPECT_EQ(fn(2), 4);
+    EXPECT_EQ(fn(3), 9);
+    EXPECT_EQ(fn(4), 16);
+}
+
 #endif

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -1,4 +1,17 @@
 #include <boost/ut.hpp>
 
+void register_allocator_tests();
+void register_inline_hook_tests();
+void register_inline_hook_x64_tests();
+void register_mid_hook_tests();
+void register_vmt_hook_tests();
+
 int main() {
+    register_allocator_tests();
+    register_inline_hook_tests();
+    register_inline_hook_x64_tests();
+    register_mid_hook_tests();
+    register_vmt_hook_tests();
+
+    return boost::ut::cfg<>.run({.report_errors = true}) ? 1 : 0;
 }

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -1,17 +1,6 @@
-#include <boost/ut.hpp>
+#include <gtest/gtest.h>
 
-void register_allocator_tests();
-void register_inline_hook_tests();
-void register_inline_hook_x64_tests();
-void register_mid_hook_tests();
-void register_vmt_hook_tests();
-
-int main() {
-    register_allocator_tests();
-    register_inline_hook_tests();
-    register_inline_hook_x64_tests();
-    register_mid_hook_tests();
-    register_vmt_hook_tests();
-
-    return boost::ut::cfg<>.run({.report_errors = true}) ? 1 : 0;
+int main(int argc, char** argv) {
+    testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
 }

--- a/test/mid_hook.cpp
+++ b/test/mid_hook.cpp
@@ -22,7 +22,7 @@ TEST(MidHook, MidHookToChangeARegister) {
 #if SAFETYHOOK_ARCH_X86_64
             ctx.rdi = 1337 - 42;
 #elif SAFETYHOOK_ARCH_X86_32
-            ctx.edi = 1337 - 42;
+            *reinterpret_cast<int*>(ctx.esp + 4) = 1337 - 42;
 #endif
 #endif
         }
@@ -95,7 +95,7 @@ TEST(MidHook, MidHookEnableAndDisable) {
 #if SAFETYHOOK_ARCH_X86_64
             ctx.rdi = 1337 - 42;
 #elif SAFETYHOOK_ARCH_X86_32
-            ctx.edi = 1337 - 42;
+            *reinterpret_cast<int*>(ctx.esp + 4) = 1337 - 42;
 #endif
 #endif
         }

--- a/test/mid_hook.cpp
+++ b/test/mid_hook.cpp
@@ -1,137 +1,131 @@
-#include <boost/ut.hpp>
+#include <gtest/gtest.h>
 #include <safetyhook.hpp>
 
-using namespace boost::ut;
+TEST(MidHook, MidHookToChangeARegister) {
+    struct Target {
+        SAFETYHOOK_NOINLINE static int SAFETYHOOK_FASTCALL add_42(int a) { return a + 42; }
+    };
 
-void register_mid_hook_tests() {
-suite<"mid hook"> mid_hook_tests = [] {
-    "Mid hook to change a register"_test = [] {
-        struct Target {
-            SAFETYHOOK_NOINLINE static int SAFETYHOOK_FASTCALL add_42(int a) { return a + 42; }
-        };
+    EXPECT_EQ(Target::add_42(0), 42);
 
-        expect(Target::add_42(0) == 42_i);
+    static SafetyHookMid hook;
 
-        static SafetyHookMid hook;
-
-        struct Hook {
-            static void add_42(SafetyHookContext& ctx) {
+    struct Hook {
+        static void add_42(SafetyHookContext& ctx) {
 #if SAFETYHOOK_OS_WINDOWS
 #if SAFETYHOOK_ARCH_X86_64
-                ctx.rcx = 1337 - 42;
+            ctx.rcx = 1337 - 42;
 #elif SAFETYHOOK_ARCH_X86_32
-                ctx.ecx = 1337 - 42;
+            ctx.ecx = 1337 - 42;
 #endif
 #elif SAFETYHOOK_OS_LINUX
 #if SAFETYHOOK_ARCH_X86_64
-                ctx.rdi = 1337 - 42;
+            ctx.rdi = 1337 - 42;
 #elif SAFETYHOOK_ARCH_X86_32
-                ctx.edi = 1337 - 42;
+            ctx.edi = 1337 - 42;
 #endif
 #endif
-            }
-        };
-
-        auto hook_result = SafetyHookMid::create(Target::add_42, Hook::add_42);
-
-        expect(hook_result.has_value());
-
-        hook = std::move(*hook_result);
-
-        expect(Target::add_42(1) == 1337_i);
-
-        hook.reset();
-
-        expect(Target::add_42(2) == 44_i);
+        }
     };
+
+    auto hook_result = SafetyHookMid::create(Target::add_42, Hook::add_42);
+
+    ASSERT_TRUE(hook_result.has_value());
+
+    hook = std::move(*hook_result);
+
+    EXPECT_EQ(Target::add_42(1), 1337);
+
+    hook.reset();
+
+    EXPECT_EQ(Target::add_42(2), 44);
+}
 
 #if SAFETYHOOK_ARCH_X86_64
-    "Mid hook to change an XMM register"_test = [] {
-        struct Target {
-            SAFETYHOOK_NOINLINE static float SAFETYHOOK_FASTCALL add_42(float a) { return a + 0.42f; }
-        };
-
-        expect(Target::add_42(0.0f) == 0.42_f);
-
-        static SafetyHookMid hook;
-
-        struct Hook {
-            static void add_42(SafetyHookContext& ctx) { ctx.xmm0.f32[0] = 1337.0f - 0.42f; }
-        };
-
-        auto hook_result = SafetyHookMid::create(Target::add_42, Hook::add_42);
-
-        expect(hook_result.has_value());
-
-        hook = std::move(*hook_result);
-
-        expect(Target::add_42(1.0f) == 1337.0_f);
-
-        hook.reset();
-
-        expect(Target::add_42(2.0f) == 2.42_f);
+TEST(MidHook, MidHookToChangeAnXMMRegister) {
+    struct Target {
+        SAFETYHOOK_NOINLINE static float SAFETYHOOK_FASTCALL add_42(float a) { return a + 0.42f; }
     };
+
+    EXPECT_FLOAT_EQ(Target::add_42(0.0f), 0.42f);
+
+    static SafetyHookMid hook;
+
+    struct Hook {
+        static void add_42(SafetyHookContext& ctx) { ctx.xmm0.f32[0] = 1337.0f - 0.42f; }
+    };
+
+    auto hook_result = SafetyHookMid::create(Target::add_42, Hook::add_42);
+
+    ASSERT_TRUE(hook_result.has_value());
+
+    hook = std::move(*hook_result);
+
+    EXPECT_FLOAT_EQ(Target::add_42(1.0f), 1337.0f);
+
+    hook.reset();
+
+    EXPECT_FLOAT_EQ(Target::add_42(2.0f), 2.42f);
+}
 #endif
 
-    "Mid hook enable and disable"_test = [] {
-        struct Target {
-            SAFETYHOOK_NOINLINE static int SAFETYHOOK_FASTCALL add_42(int a) {
-                volatile int b = a;
-                return b + 42;
-            }
-        };
+TEST(MidHook, MidHookEnableAndDisable) {
+    struct Target {
+        SAFETYHOOK_NOINLINE static int SAFETYHOOK_FASTCALL add_42(int a) {
+            volatile int b = a;
+            return b + 42;
+        }
+    };
 
-        expect(Target::add_42(0) == 42_i);
-        expect(Target::add_42(1) == 43_i);
-        expect(Target::add_42(2) == 44_i);
+    EXPECT_EQ(Target::add_42(0), 42);
+    EXPECT_EQ(Target::add_42(1), 43);
+    EXPECT_EQ(Target::add_42(2), 44);
 
-        static SafetyHookMid hook;
+    static SafetyHookMid hook;
 
-        struct Hook {
-            static void add_42(SafetyHookContext& ctx) {
+    struct Hook {
+        static void add_42(SafetyHookContext& ctx) {
 #if SAFETYHOOK_OS_WINDOWS
 #if SAFETYHOOK_ARCH_X86_64
-                ctx.rcx = 1337 - 42;
+            ctx.rcx = 1337 - 42;
 #elif SAFETYHOOK_ARCH_X86_32
-                ctx.ecx = 1337 - 42;
+            ctx.ecx = 1337 - 42;
 #endif
 #elif SAFETYHOOK_OS_LINUX
 #if SAFETYHOOK_ARCH_X86_64
-                ctx.rdi = 1337 - 42;
+            ctx.rdi = 1337 - 42;
 #elif SAFETYHOOK_ARCH_X86_32
-                ctx.edi = 1337 - 42;
+            ctx.edi = 1337 - 42;
 #endif
 #endif
-            }
-        };
-
-        auto hook_result = SafetyHookMid::create(Target::add_42, Hook::add_42, SafetyHookMid::StartDisabled);
-
-        expect(hook_result.has_value());
-
-        hook = std::move(*hook_result);
-
-        expect(Target::add_42(0) == 42_i);
-        expect(Target::add_42(1) == 43_i);
-        expect(Target::add_42(2) == 44_i);
-
-        expect(hook.enable().has_value());
-
-        expect(Target::add_42(1) == 1337_i);
-        expect(Target::add_42(2) == 1337_i);
-        expect(Target::add_42(3) == 1337_i);
-
-        expect(hook.disable().has_value());
-
-        expect(Target::add_42(0) == 42_i);
-        expect(Target::add_42(1) == 43_i);
-        expect(Target::add_42(2) == 44_i);
-
-        hook.reset();
-
-        expect(Target::add_42(0) == 42_i);
-        expect(Target::add_42(1) == 43_i);
-        expect(Target::add_42(2) == 44_i);
+        }
     };
-};
+
+    auto hook_result = SafetyHookMid::create(Target::add_42, Hook::add_42, SafetyHookMid::StartDisabled);
+
+    ASSERT_TRUE(hook_result.has_value());
+
+    hook = std::move(*hook_result);
+
+    EXPECT_EQ(Target::add_42(0), 42);
+    EXPECT_EQ(Target::add_42(1), 43);
+    EXPECT_EQ(Target::add_42(2), 44);
+
+    ASSERT_TRUE(hook.enable().has_value());
+
+    EXPECT_EQ(Target::add_42(1), 1337);
+    EXPECT_EQ(Target::add_42(2), 1337);
+    EXPECT_EQ(Target::add_42(3), 1337);
+
+    ASSERT_TRUE(hook.disable().has_value());
+
+    EXPECT_EQ(Target::add_42(0), 42);
+    EXPECT_EQ(Target::add_42(1), 43);
+    EXPECT_EQ(Target::add_42(2), 44);
+
+    hook.reset();
+
+    EXPECT_EQ(Target::add_42(0), 42);
+    EXPECT_EQ(Target::add_42(1), 43);
+    EXPECT_EQ(Target::add_42(2), 44);
 }

--- a/test/mid_hook.cpp
+++ b/test/mid_hook.cpp
@@ -6,9 +6,13 @@ TEST(MidHook, MidHookToChangeARegister) {
         SAFETYHOOK_NOINLINE static int SAFETYHOOK_FASTCALL add_42(int a) { return a + 42; }
     };
 
-    EXPECT_EQ(Target::add_42(0), 42);
+    using Add42Fn = int(SAFETYHOOK_FASTCALL*)(int);
+    // Force a real indirect call so MinGW Release cannot optimize around runtime patching.
+    Add42Fn volatile add_42 = Target::add_42;
 
-    static SafetyHookMid hook;
+    EXPECT_EQ(add_42(0), 42);
+
+    SafetyHookMid hook;
 
     struct Hook {
         static void add_42(SafetyHookContext& ctx) {
@@ -34,11 +38,11 @@ TEST(MidHook, MidHookToChangeARegister) {
 
     hook = std::move(*hook_result);
 
-    EXPECT_EQ(Target::add_42(1), 1337);
+    EXPECT_EQ(add_42(1), 1337);
 
     hook.reset();
 
-    EXPECT_EQ(Target::add_42(2), 44);
+    EXPECT_EQ(add_42(2), 44);
 }
 
 #if SAFETYHOOK_ARCH_X86_64
@@ -47,9 +51,13 @@ TEST(MidHook, MidHookToChangeAnXMMRegister) {
         SAFETYHOOK_NOINLINE static float SAFETYHOOK_FASTCALL add_42(float a) { return a + 0.42f; }
     };
 
-    EXPECT_FLOAT_EQ(Target::add_42(0.0f), 0.42f);
+    using Add42Fn = float(SAFETYHOOK_FASTCALL*)(float);
+    // Force a real indirect call so MinGW Release cannot optimize around runtime patching.
+    Add42Fn volatile add_42 = Target::add_42;
 
-    static SafetyHookMid hook;
+    EXPECT_FLOAT_EQ(add_42(0.0f), 0.42f);
+
+    SafetyHookMid hook;
 
     struct Hook {
         static void add_42(SafetyHookContext& ctx) { ctx.xmm0.f32[0] = 1337.0f - 0.42f; }
@@ -61,11 +69,11 @@ TEST(MidHook, MidHookToChangeAnXMMRegister) {
 
     hook = std::move(*hook_result);
 
-    EXPECT_FLOAT_EQ(Target::add_42(1.0f), 1337.0f);
+    EXPECT_FLOAT_EQ(add_42(1.0f), 1337.0f);
 
     hook.reset();
 
-    EXPECT_FLOAT_EQ(Target::add_42(2.0f), 2.42f);
+    EXPECT_FLOAT_EQ(add_42(2.0f), 2.42f);
 }
 #endif
 
@@ -77,11 +85,15 @@ TEST(MidHook, MidHookEnableAndDisable) {
         }
     };
 
-    EXPECT_EQ(Target::add_42(0), 42);
-    EXPECT_EQ(Target::add_42(1), 43);
-    EXPECT_EQ(Target::add_42(2), 44);
+    using Add42Fn = int(SAFETYHOOK_FASTCALL*)(int);
+    // Force a real indirect call so MinGW Release cannot optimize around runtime patching.
+    Add42Fn volatile add_42 = Target::add_42;
 
-    static SafetyHookMid hook;
+    EXPECT_EQ(add_42(0), 42);
+    EXPECT_EQ(add_42(1), 43);
+    EXPECT_EQ(add_42(2), 44);
+
+    SafetyHookMid hook;
 
     struct Hook {
         static void add_42(SafetyHookContext& ctx) {
@@ -107,25 +119,25 @@ TEST(MidHook, MidHookEnableAndDisable) {
 
     hook = std::move(*hook_result);
 
-    EXPECT_EQ(Target::add_42(0), 42);
-    EXPECT_EQ(Target::add_42(1), 43);
-    EXPECT_EQ(Target::add_42(2), 44);
+    EXPECT_EQ(add_42(0), 42);
+    EXPECT_EQ(add_42(1), 43);
+    EXPECT_EQ(add_42(2), 44);
 
     ASSERT_TRUE(hook.enable().has_value());
 
-    EXPECT_EQ(Target::add_42(1), 1337);
-    EXPECT_EQ(Target::add_42(2), 1337);
-    EXPECT_EQ(Target::add_42(3), 1337);
+    EXPECT_EQ(add_42(1), 1337);
+    EXPECT_EQ(add_42(2), 1337);
+    EXPECT_EQ(add_42(3), 1337);
 
     ASSERT_TRUE(hook.disable().has_value());
 
-    EXPECT_EQ(Target::add_42(0), 42);
-    EXPECT_EQ(Target::add_42(1), 43);
-    EXPECT_EQ(Target::add_42(2), 44);
+    EXPECT_EQ(add_42(0), 42);
+    EXPECT_EQ(add_42(1), 43);
+    EXPECT_EQ(add_42(2), 44);
 
     hook.reset();
 
-    EXPECT_EQ(Target::add_42(0), 42);
-    EXPECT_EQ(Target::add_42(1), 43);
-    EXPECT_EQ(Target::add_42(2), 44);
+    EXPECT_EQ(add_42(0), 42);
+    EXPECT_EQ(add_42(1), 43);
+    EXPECT_EQ(add_42(2), 44);
 }

--- a/test/mid_hook.cpp
+++ b/test/mid_hook.cpp
@@ -3,7 +3,8 @@
 
 using namespace boost::ut;
 
-static suite<"mid hook"> mid_hook_tests = [] {
+void register_mid_hook_tests() {
+suite<"mid hook"> mid_hook_tests = [] {
     "Mid hook to change a register"_test = [] {
         struct Target {
             SAFETYHOOK_NOINLINE static int SAFETYHOOK_FASTCALL add_42(int a) { return a + 42; }
@@ -133,3 +134,4 @@ static suite<"mid hook"> mid_hook_tests = [] {
         expect(Target::add_42(2) == 44_i);
     };
 };
+}

--- a/test/vmt_hook.cpp
+++ b/test/vmt_hook.cpp
@@ -1,9 +1,8 @@
-#include <boost/ut.hpp>
+#include <gtest/gtest.h>
 #include <safetyhook.hpp>
 
 #include "vmt_targets.hpp"
 
-using namespace boost::ut;
 using namespace safetyhook::test;
 
 #if SAFETYHOOK_ABI_MSVC
@@ -12,319 +11,315 @@ static constexpr auto VMT_OFFSET = 0;
 static constexpr auto VMT_OFFSET = 1;
 #endif
 
-void register_vmt_hook_tests() {
-suite<"vmt hook"> vmt_hook_tests = [] {
-    "VMT hook an object instance"_test = [] {
-        auto target = make_single_target();
+TEST(VmtHook, VMTHookAnObjectInstance) {
+    auto target = make_single_target();
 
-        expect(target->add_42(0) == 42_i);
+    EXPECT_EQ(target->add_42(0), 42);
 
-        static SafetyHookVmt target_hook{};
-        static SafetyHookVm add_42_hook{};
+    static SafetyHookVmt target_hook{};
+    static SafetyHookVm add_42_hook{};
 
-        struct Hook : SingleTarget {
-            int hooked_add_42(int a) { return add_42_hook.thiscall<int>(this, a) + 1337; }
-        };
-
-        auto vmt_result = SafetyHookVmt::create(target.get());
-
-        expect(vmt_result.has_value());
-
-        target_hook = std::move(*vmt_result);
-
-        auto vm_result = target_hook.hook_method(1 + VMT_OFFSET, &Hook::hooked_add_42);
-
-        expect(vm_result.has_value());
-
-        add_42_hook = std::move(*vm_result);
-
-        expect(target->add_42(1) == 1380_i);
-
-        add_42_hook.reset();
-
-        expect(target->add_42(2) == 44_i);
-
-        target_hook.reset();
+    struct Hook : SingleTarget {
+        int hooked_add_42(int a) { return add_42_hook.thiscall<int>(this, a) + 1337; }
     };
 
-    "Resetting the VMT hook removes all VM hooks for that object"_test = [] {
-        auto target = make_dual_target();
+    auto vmt_result = SafetyHookVmt::create(target.get());
 
-        expect(target->add_42(0) == 42_i);
-        expect(target->add_43(0) == 43_i);
+    ASSERT_TRUE(vmt_result.has_value());
 
-        static SafetyHookVmt target_hook{};
-        static SafetyHookVm add_42_hook{};
-        static SafetyHookVm add_43_hook{};
+    target_hook = std::move(*vmt_result);
 
-        struct Hook : DualTarget {
-            int hooked_add_42(int a) { return add_42_hook.thiscall<int>(this, a) + 1337; }
-            int hooked_add_43(int a) { return add_43_hook.thiscall<int>(this, a) + 1337; }
-        };
+    auto vm_result = target_hook.hook_method(1 + VMT_OFFSET, &Hook::hooked_add_42);
 
-        auto vmt_result = SafetyHookVmt::create(target.get());
+    ASSERT_TRUE(vm_result.has_value());
 
-        expect(vmt_result.has_value());
+    add_42_hook = std::move(*vm_result);
 
-        target_hook = std::move(*vmt_result);
+    EXPECT_EQ(target->add_42(1), 1380);
 
-        auto vm_result = target_hook.hook_method(1 + VMT_OFFSET, &Hook::hooked_add_42);
+    add_42_hook.reset();
 
-        expect(vm_result.has_value());
+    EXPECT_EQ(target->add_42(2), 44);
 
-        add_42_hook = std::move(*vm_result);
+    target_hook.reset();
+}
 
-        expect(target->add_42(1) == 1380_i);
+TEST(VmtHook, ResettingTheVMTHookRemovesAllVMHooksForThatObject) {
+    auto target = make_dual_target();
 
-        vm_result = target_hook.hook_method(2 + VMT_OFFSET, &Hook::hooked_add_43);
+    EXPECT_EQ(target->add_42(0), 42);
+    EXPECT_EQ(target->add_43(0), 43);
 
-        expect(vm_result.has_value());
+    static SafetyHookVmt target_hook{};
+    static SafetyHookVm add_42_hook{};
+    static SafetyHookVm add_43_hook{};
 
-        add_43_hook = std::move(*vm_result);
-
-        expect(target->add_43(1) == 1381_i);
-
-        target_hook.reset();
-
-        expect(target->add_42(2) == 44_i);
-        expect(target->add_43(2) == 45_i);
-
-        add_42_hook.reset();
-        add_43_hook.reset();
+    struct Hook : DualTarget {
+        int hooked_add_42(int a) { return add_42_hook.thiscall<int>(this, a) + 1337; }
+        int hooked_add_43(int a) { return add_43_hook.thiscall<int>(this, a) + 1337; }
     };
 
-    "VMT hooking an object maintains correct RTTI"_test = [] {
-        auto target = make_single_target();
+    auto vmt_result = SafetyHookVmt::create(target.get());
 
-        expect(target->add_42(0) == 42_i);
-        expect(neq(dynamic_cast<SingleInterface*>(target.get()), nullptr));
+    ASSERT_TRUE(vmt_result.has_value());
 
-        static SafetyHookVmt target_hook{};
-        static SafetyHookVm add_42_hook{};
+    target_hook = std::move(*vmt_result);
 
-        struct Hook : SingleTarget {
-            int hooked_add_42(int a) { return add_42_hook.thiscall<int>(this, a) + 1337; }
-        };
+    auto vm_result = target_hook.hook_method(1 + VMT_OFFSET, &Hook::hooked_add_42);
 
-        auto vmt_result = SafetyHookVmt::create(target.get());
+    ASSERT_TRUE(vm_result.has_value());
 
-        expect(vmt_result.has_value());
+    add_42_hook = std::move(*vm_result);
 
-        target_hook = std::move(*vmt_result);
+    EXPECT_EQ(target->add_42(1), 1380);
 
-        auto vm_result = target_hook.hook_method(1 + VMT_OFFSET, &Hook::hooked_add_42);
+    vm_result = target_hook.hook_method(2 + VMT_OFFSET, &Hook::hooked_add_43);
 
-        expect(vm_result.has_value());
+    ASSERT_TRUE(vm_result.has_value());
 
-        add_42_hook = std::move(*vm_result);
+    add_43_hook = std::move(*vm_result);
 
-        expect(target->add_42(1) == 1380_i);
-        expect(neq(dynamic_cast<SingleInterface*>(target.get()), nullptr));
+    EXPECT_EQ(target->add_43(1), 1381);
 
-        add_42_hook.reset();
-        target_hook.reset();
+    target_hook.reset();
+
+    EXPECT_EQ(target->add_42(2), 44);
+    EXPECT_EQ(target->add_43(2), 45);
+
+    add_42_hook.reset();
+    add_43_hook.reset();
+}
+
+TEST(VmtHook, VMTHookingAnObjectMaintainsCorrectRTTI) {
+    auto target = make_single_target();
+
+    EXPECT_EQ(target->add_42(0), 42);
+    EXPECT_NE(dynamic_cast<SingleInterface*>(target.get()), nullptr);
+
+    static SafetyHookVmt target_hook{};
+    static SafetyHookVm add_42_hook{};
+
+    struct Hook : SingleTarget {
+        int hooked_add_42(int a) { return add_42_hook.thiscall<int>(this, a) + 1337; }
     };
 
-    "Can safely destroy VmtHook after object is deleted"_test = [] {
-        auto target = make_single_target();
+    auto vmt_result = SafetyHookVmt::create(target.get());
 
-        expect(target->add_42(0) == 42_i);
+    ASSERT_TRUE(vmt_result.has_value());
 
-        static SafetyHookVmt target_hook{};
-        static SafetyHookVm add_42_hook{};
+    target_hook = std::move(*vmt_result);
 
-        struct Hook : SingleTarget {
-            int hooked_add_42(int a) { return add_42_hook.thiscall<int>(this, a) + 1337; }
-        };
+    auto vm_result = target_hook.hook_method(1 + VMT_OFFSET, &Hook::hooked_add_42);
 
-        auto vmt_result = SafetyHookVmt::create(target.get());
+    ASSERT_TRUE(vm_result.has_value());
 
-        expect(vmt_result.has_value());
+    add_42_hook = std::move(*vm_result);
 
-        target_hook = std::move(*vmt_result);
+    EXPECT_EQ(target->add_42(1), 1380);
+    EXPECT_NE(dynamic_cast<SingleInterface*>(target.get()), nullptr);
 
-        auto vm_result = target_hook.hook_method(1 + VMT_OFFSET, &Hook::hooked_add_42);
+    add_42_hook.reset();
+    target_hook.reset();
+}
 
-        expect(vm_result.has_value());
+TEST(VmtHook, CanSafelyDestroyVmtHookAfterObjectIsDeleted) {
+    auto target = make_single_target();
 
-        add_42_hook = std::move(*vm_result);
+    EXPECT_EQ(target->add_42(0), 42);
 
-        expect(target->add_42(1) == 1380_i);
+    static SafetyHookVmt target_hook{};
+    static SafetyHookVm add_42_hook{};
 
-        target.reset();
-        target_hook.reset();
-        add_42_hook.reset();
+    struct Hook : SingleTarget {
+        int hooked_add_42(int a) { return add_42_hook.thiscall<int>(this, a) + 1337; }
     };
 
-    "Can apply an existing VMT hook to more than one object"_test = [] {
-        auto target = make_single_target();
-        auto target0 = make_single_target();
-        auto target1 = make_single_target();
-        auto target2 = make_single_target();
+    auto vmt_result = SafetyHookVmt::create(target.get());
 
-        expect(target->add_42(0) == 42_i);
+    ASSERT_TRUE(vmt_result.has_value());
 
-        static SafetyHookVmt target_hook{};
-        static SafetyHookVm add_42_hook{};
+    target_hook = std::move(*vmt_result);
 
-        struct Hook : SingleTarget {
-            int hooked_add_42(int a) { return add_42_hook.thiscall<int>(this, a) + 1337; }
-        };
+    auto vm_result = target_hook.hook_method(1 + VMT_OFFSET, &Hook::hooked_add_42);
 
-        auto vmt_result = SafetyHookVmt::create(target.get());
+    ASSERT_TRUE(vm_result.has_value());
 
-        expect(vmt_result.has_value());
+    add_42_hook = std::move(*vm_result);
 
-        target_hook = std::move(*vmt_result);
+    EXPECT_EQ(target->add_42(1), 1380);
 
-        auto vm_result = target_hook.hook_method(1 + VMT_OFFSET, &Hook::hooked_add_42);
+    target.reset();
+    target_hook.reset();
+    add_42_hook.reset();
+}
 
-        expect(vm_result.has_value());
+TEST(VmtHook, CanApplyAnExistingVMTHookToMoreThanOneObject) {
+    auto target = make_single_target();
+    auto target0 = make_single_target();
+    auto target1 = make_single_target();
+    auto target2 = make_single_target();
 
-        add_42_hook = std::move(*vm_result);
+    EXPECT_EQ(target->add_42(0), 42);
 
-        target_hook.apply(target0.get());
-        target_hook.apply(target1.get());
-        target_hook.apply(target2.get());
+    static SafetyHookVmt target_hook{};
+    static SafetyHookVm add_42_hook{};
 
-        expect(target->add_42(1) == 1380_i);
-        expect(target0->add_42(1) == 1380_i);
-        expect(target1->add_42(1) == 1380_i);
-        expect(target2->add_42(1) == 1380_i);
-
-        add_42_hook.reset();
-
-        expect(target->add_42(2) == 44_i);
-        expect(target0->add_42(2) == 44_i);
-        expect(target1->add_42(2) == 44_i);
-        expect(target2->add_42(2) == 44_i);
-
-        target_hook.reset();
+    struct Hook : SingleTarget {
+        int hooked_add_42(int a) { return add_42_hook.thiscall<int>(this, a) + 1337; }
     };
 
-    "Can remove an object that was previously VMT hooked"_test = [] {
-        auto target = make_single_target();
-        auto target0 = make_single_target();
-        auto target1 = make_single_target();
-        auto target2 = make_single_target();
+    auto vmt_result = SafetyHookVmt::create(target.get());
 
-        expect(target->add_42(0) == 42_i);
+    ASSERT_TRUE(vmt_result.has_value());
 
-        static SafetyHookVmt target_hook{};
-        static SafetyHookVm add_42_hook{};
+    target_hook = std::move(*vmt_result);
 
-        struct Hook : SingleTarget {
-            int hooked_add_42(int a) { return add_42_hook.thiscall<int>(this, a) + 1337; }
-        };
+    auto vm_result = target_hook.hook_method(1 + VMT_OFFSET, &Hook::hooked_add_42);
 
-        auto vmt_result = SafetyHookVmt::create(target.get());
+    ASSERT_TRUE(vm_result.has_value());
 
-        expect(vmt_result.has_value());
+    add_42_hook = std::move(*vm_result);
 
-        target_hook = std::move(*vmt_result);
+    target_hook.apply(target0.get());
+    target_hook.apply(target1.get());
+    target_hook.apply(target2.get());
 
-        auto vm_result = target_hook.hook_method(1 + VMT_OFFSET, &Hook::hooked_add_42);
+    EXPECT_EQ(target->add_42(1), 1380);
+    EXPECT_EQ(target0->add_42(1), 1380);
+    EXPECT_EQ(target1->add_42(1), 1380);
+    EXPECT_EQ(target2->add_42(1), 1380);
 
-        expect(vm_result.has_value());
+    add_42_hook.reset();
 
-        add_42_hook = std::move(*vm_result);
+    EXPECT_EQ(target->add_42(2), 44);
+    EXPECT_EQ(target0->add_42(2), 44);
+    EXPECT_EQ(target1->add_42(2), 44);
+    EXPECT_EQ(target2->add_42(2), 44);
 
-        target_hook.apply(target0.get());
-        target_hook.apply(target1.get());
-        target_hook.apply(target2.get());
+    target_hook.reset();
+}
 
-        expect(target->add_42(1) == 1380_i);
-        expect(target0->add_42(1) == 1380_i);
-        expect(target1->add_42(1) == 1380_i);
-        expect(target2->add_42(1) == 1380_i);
+TEST(VmtHook, CanRemoveAnObjectThatWasPreviouslyVMTHooked) {
+    auto target = make_single_target();
+    auto target0 = make_single_target();
+    auto target1 = make_single_target();
+    auto target2 = make_single_target();
 
-        target_hook.remove(target0.get());
+    EXPECT_EQ(target->add_42(0), 42);
 
-        expect(target->add_42(2) == 1381_i);
-        expect(target0->add_42(2) == 44_i);
-        expect(target1->add_42(2) == 1381_i);
-        expect(target2->add_42(2) == 1381_i);
+    static SafetyHookVmt target_hook{};
+    static SafetyHookVm add_42_hook{};
 
-        target_hook.remove(target2.get());
-
-        expect(target->add_42(2) == 1381_i);
-        expect(target0->add_42(2) == 44_i);
-        expect(target1->add_42(2) == 1381_i);
-        expect(target2->add_42(2) == 44_i);
-
-        target_hook.remove(target.get());
-
-        expect(target->add_42(2) == 44_i);
-        expect(target0->add_42(2) == 44_i);
-        expect(target1->add_42(2) == 1381_i);
-        expect(target2->add_42(2) == 44_i);
-
-        target_hook.remove(target1.get());
-
-        expect(target->add_42(2) == 44_i);
-        expect(target0->add_42(2) == 44_i);
-        expect(target1->add_42(2) == 44_i);
-        expect(target2->add_42(2) == 44_i);
-
-        add_42_hook.reset();
-        target_hook.reset();
+    struct Hook : SingleTarget {
+        int hooked_add_42(int a) { return add_42_hook.thiscall<int>(this, a) + 1337; }
     };
 
-    "VMT hook an object instance with easy API"_test = [] {
-        auto target = make_single_target();
+    auto vmt_result = SafetyHookVmt::create(target.get());
 
-        expect(target->add_42(0) == 42_i);
+    ASSERT_TRUE(vmt_result.has_value());
 
-        static SafetyHookVmt target_hook{};
-        static SafetyHookVm add_42_hook{};
+    target_hook = std::move(*vmt_result);
 
-        struct Hook : SingleTarget {
-            int hooked_add_42(int a) { return add_42_hook.thiscall<int>(this, a) + 1337; }
-        };
+    auto vm_result = target_hook.hook_method(1 + VMT_OFFSET, &Hook::hooked_add_42);
 
-        target_hook = safetyhook::create_vmt(target.get());
-        add_42_hook = safetyhook::create_vm(target_hook, 1 + VMT_OFFSET, &Hook::hooked_add_42);
+    ASSERT_TRUE(vm_result.has_value());
 
-        expect(target->add_42(1) == 1380_i);
+    add_42_hook = std::move(*vm_result);
 
-        add_42_hook.reset();
+    target_hook.apply(target0.get());
+    target_hook.apply(target1.get());
+    target_hook.apply(target2.get());
 
-        expect(target->add_42(2) == 44_i);
+    EXPECT_EQ(target->add_42(1), 1380);
+    EXPECT_EQ(target0->add_42(1), 1380);
+    EXPECT_EQ(target1->add_42(1), 1380);
+    EXPECT_EQ(target2->add_42(1), 1380);
 
-        target_hook.reset();
+    target_hook.remove(target0.get());
+
+    EXPECT_EQ(target->add_42(2), 1381);
+    EXPECT_EQ(target0->add_42(2), 44);
+    EXPECT_EQ(target1->add_42(2), 1381);
+    EXPECT_EQ(target2->add_42(2), 1381);
+
+    target_hook.remove(target2.get());
+
+    EXPECT_EQ(target->add_42(2), 1381);
+    EXPECT_EQ(target0->add_42(2), 44);
+    EXPECT_EQ(target1->add_42(2), 1381);
+    EXPECT_EQ(target2->add_42(2), 44);
+
+    target_hook.remove(target.get());
+
+    EXPECT_EQ(target->add_42(2), 44);
+    EXPECT_EQ(target0->add_42(2), 44);
+    EXPECT_EQ(target1->add_42(2), 1381);
+    EXPECT_EQ(target2->add_42(2), 44);
+
+    target_hook.remove(target1.get());
+
+    EXPECT_EQ(target->add_42(2), 44);
+    EXPECT_EQ(target0->add_42(2), 44);
+    EXPECT_EQ(target1->add_42(2), 44);
+    EXPECT_EQ(target2->add_42(2), 44);
+
+    add_42_hook.reset();
+    target_hook.reset();
+}
+
+TEST(VmtHook, VMTHookAnObjectInstanceWithEasyAPI) {
+    auto target = make_single_target();
+
+    EXPECT_EQ(target->add_42(0), 42);
+
+    static SafetyHookVmt target_hook{};
+    static SafetyHookVm add_42_hook{};
+
+    struct Hook : SingleTarget {
+        int hooked_add_42(int a) { return add_42_hook.thiscall<int>(this, a) + 1337; }
     };
 
-    "VMT hook preserves dynamic_cast with cross-cast"_test = [] {
-        auto target = make_cast_target();
+    target_hook = safetyhook::create_vmt(target.get());
+    add_42_hook = safetyhook::create_vm(target_hook, 1 + VMT_OFFSET, &Hook::hooked_add_42);
 
-        CastBase2* base2 = target.get();
+    EXPECT_EQ(target->add_42(1), 1380);
 
-        static SafetyHookVmt base2_hook{};
-        static SafetyHookVm add_1337_hook{};
+    add_42_hook.reset();
 
-        struct Hook : CastTarget {
-            int hooked_add_1337(int a) { return add_1337_hook.thiscall<int>(this, a) + 42; }
-        };
+    EXPECT_EQ(target->add_42(2), 44);
 
-        auto vmt_result = SafetyHookVmt::create(base2);
-        expect(vmt_result.has_value());
-        base2_hook = std::move(*vmt_result);
+    target_hook.reset();
+}
 
-        auto vm_result = base2_hook.hook_method(1 + VMT_OFFSET, &Hook::hooked_add_1337);
-        expect(vm_result.has_value());
-        add_1337_hook = std::move(*vm_result);
+TEST(VmtHook, VMTHookPreservesDynamicCastWithCrossCast) {
+    auto target = make_cast_target();
 
-        expect(base2->add_1337(1) == 1380_i);
+    CastBase2* base2 = target.get();
 
-        // Cross-cast: CastBase2* -> CastBase1*
-        // Runtime reads offset-to-top from CastBase2's vptr[-2]
-        // Without the fix this is garbage and will crash or return wrong pointer
-        CastBase1* base1 = dynamic_cast<CastBase1*>(base2);
-        expect(neq(base1, nullptr));
-        expect(base1->add_42(1) == 43_i);
+    static SafetyHookVmt base2_hook{};
+    static SafetyHookVm add_1337_hook{};
 
-        add_1337_hook.reset();
-        base2_hook.reset();
+    struct Hook : CastTarget {
+        int hooked_add_1337(int a) { return add_1337_hook.thiscall<int>(this, a) + 42; }
     };
-};
+
+    auto vmt_result = SafetyHookVmt::create(base2);
+    ASSERT_TRUE(vmt_result.has_value());
+    base2_hook = std::move(*vmt_result);
+
+    auto vm_result = base2_hook.hook_method(1 + VMT_OFFSET, &Hook::hooked_add_1337);
+    ASSERT_TRUE(vm_result.has_value());
+    add_1337_hook = std::move(*vm_result);
+
+    EXPECT_EQ(base2->add_1337(1), 1380);
+
+    // Cross-cast: CastBase2* -> CastBase1*
+    // Runtime reads offset-to-top from CastBase2's vptr[-2]
+    // Without the fix this is garbage and will crash or return wrong pointer
+    CastBase1* base1 = dynamic_cast<CastBase1*>(base2);
+    EXPECT_NE(base1, nullptr);
+    EXPECT_EQ(base1->add_42(1), 43);
+
+    add_1337_hook.reset();
+    base2_hook.reset();
 }

--- a/test/vmt_hook.cpp
+++ b/test/vmt_hook.cpp
@@ -16,11 +16,13 @@ TEST(VmtHook, VMTHookAnObjectInstance) {
 
     EXPECT_EQ(target->add_42(0), 42);
 
-    static SafetyHookVmt target_hook{};
-    static SafetyHookVm add_42_hook{};
+    SafetyHookVmt target_hook{};
+    static SafetyHookVm* add_42_hook{};
+    SafetyHookVm add_42_hook_storage{};
+    add_42_hook = &add_42_hook_storage;
 
     struct Hook : SingleTarget {
-        int hooked_add_42(int a) { return add_42_hook.thiscall<int>(this, a) + 1337; }
+        int hooked_add_42(int a) { return add_42_hook->thiscall<int>(this, a) + 1337; }
     };
 
     auto vmt_result = SafetyHookVmt::create(target.get());
@@ -33,11 +35,11 @@ TEST(VmtHook, VMTHookAnObjectInstance) {
 
     ASSERT_TRUE(vm_result.has_value());
 
-    add_42_hook = std::move(*vm_result);
+    add_42_hook_storage = std::move(*vm_result);
 
     EXPECT_EQ(target->add_42(1), 1380);
 
-    add_42_hook.reset();
+    add_42_hook_storage.reset();
 
     EXPECT_EQ(target->add_42(2), 44);
 
@@ -50,13 +52,17 @@ TEST(VmtHook, ResettingTheVMTHookRemovesAllVMHooksForThatObject) {
     EXPECT_EQ(target->add_42(0), 42);
     EXPECT_EQ(target->add_43(0), 43);
 
-    static SafetyHookVmt target_hook{};
-    static SafetyHookVm add_42_hook{};
-    static SafetyHookVm add_43_hook{};
+    SafetyHookVmt target_hook{};
+    static SafetyHookVm* add_42_hook{};
+    static SafetyHookVm* add_43_hook{};
+    SafetyHookVm add_42_hook_storage{};
+    SafetyHookVm add_43_hook_storage{};
+    add_42_hook = &add_42_hook_storage;
+    add_43_hook = &add_43_hook_storage;
 
     struct Hook : DualTarget {
-        int hooked_add_42(int a) { return add_42_hook.thiscall<int>(this, a) + 1337; }
-        int hooked_add_43(int a) { return add_43_hook.thiscall<int>(this, a) + 1337; }
+        int hooked_add_42(int a) { return add_42_hook->thiscall<int>(this, a) + 1337; }
+        int hooked_add_43(int a) { return add_43_hook->thiscall<int>(this, a) + 1337; }
     };
 
     auto vmt_result = SafetyHookVmt::create(target.get());
@@ -69,7 +75,7 @@ TEST(VmtHook, ResettingTheVMTHookRemovesAllVMHooksForThatObject) {
 
     ASSERT_TRUE(vm_result.has_value());
 
-    add_42_hook = std::move(*vm_result);
+    add_42_hook_storage = std::move(*vm_result);
 
     EXPECT_EQ(target->add_42(1), 1380);
 
@@ -77,7 +83,7 @@ TEST(VmtHook, ResettingTheVMTHookRemovesAllVMHooksForThatObject) {
 
     ASSERT_TRUE(vm_result.has_value());
 
-    add_43_hook = std::move(*vm_result);
+    add_43_hook_storage = std::move(*vm_result);
 
     EXPECT_EQ(target->add_43(1), 1381);
 
@@ -86,8 +92,8 @@ TEST(VmtHook, ResettingTheVMTHookRemovesAllVMHooksForThatObject) {
     EXPECT_EQ(target->add_42(2), 44);
     EXPECT_EQ(target->add_43(2), 45);
 
-    add_42_hook.reset();
-    add_43_hook.reset();
+    add_42_hook_storage.reset();
+    add_43_hook_storage.reset();
 }
 
 TEST(VmtHook, VMTHookingAnObjectMaintainsCorrectRTTI) {
@@ -96,11 +102,13 @@ TEST(VmtHook, VMTHookingAnObjectMaintainsCorrectRTTI) {
     EXPECT_EQ(target->add_42(0), 42);
     EXPECT_NE(dynamic_cast<SingleInterface*>(target.get()), nullptr);
 
-    static SafetyHookVmt target_hook{};
-    static SafetyHookVm add_42_hook{};
+    SafetyHookVmt target_hook{};
+    static SafetyHookVm* add_42_hook{};
+    SafetyHookVm add_42_hook_storage{};
+    add_42_hook = &add_42_hook_storage;
 
     struct Hook : SingleTarget {
-        int hooked_add_42(int a) { return add_42_hook.thiscall<int>(this, a) + 1337; }
+        int hooked_add_42(int a) { return add_42_hook->thiscall<int>(this, a) + 1337; }
     };
 
     auto vmt_result = SafetyHookVmt::create(target.get());
@@ -113,12 +121,12 @@ TEST(VmtHook, VMTHookingAnObjectMaintainsCorrectRTTI) {
 
     ASSERT_TRUE(vm_result.has_value());
 
-    add_42_hook = std::move(*vm_result);
+    add_42_hook_storage = std::move(*vm_result);
 
     EXPECT_EQ(target->add_42(1), 1380);
     EXPECT_NE(dynamic_cast<SingleInterface*>(target.get()), nullptr);
 
-    add_42_hook.reset();
+    add_42_hook_storage.reset();
     target_hook.reset();
 }
 
@@ -127,11 +135,13 @@ TEST(VmtHook, CanSafelyDestroyVmtHookAfterObjectIsDeleted) {
 
     EXPECT_EQ(target->add_42(0), 42);
 
-    static SafetyHookVmt target_hook{};
-    static SafetyHookVm add_42_hook{};
+    SafetyHookVmt target_hook{};
+    static SafetyHookVm* add_42_hook{};
+    SafetyHookVm add_42_hook_storage{};
+    add_42_hook = &add_42_hook_storage;
 
     struct Hook : SingleTarget {
-        int hooked_add_42(int a) { return add_42_hook.thiscall<int>(this, a) + 1337; }
+        int hooked_add_42(int a) { return add_42_hook->thiscall<int>(this, a) + 1337; }
     };
 
     auto vmt_result = SafetyHookVmt::create(target.get());
@@ -144,13 +154,13 @@ TEST(VmtHook, CanSafelyDestroyVmtHookAfterObjectIsDeleted) {
 
     ASSERT_TRUE(vm_result.has_value());
 
-    add_42_hook = std::move(*vm_result);
+    add_42_hook_storage = std::move(*vm_result);
 
     EXPECT_EQ(target->add_42(1), 1380);
 
     target.reset();
     target_hook.reset();
-    add_42_hook.reset();
+    add_42_hook_storage.reset();
 }
 
 TEST(VmtHook, CanApplyAnExistingVMTHookToMoreThanOneObject) {
@@ -161,11 +171,13 @@ TEST(VmtHook, CanApplyAnExistingVMTHookToMoreThanOneObject) {
 
     EXPECT_EQ(target->add_42(0), 42);
 
-    static SafetyHookVmt target_hook{};
-    static SafetyHookVm add_42_hook{};
+    SafetyHookVmt target_hook{};
+    static SafetyHookVm* add_42_hook{};
+    SafetyHookVm add_42_hook_storage{};
+    add_42_hook = &add_42_hook_storage;
 
     struct Hook : SingleTarget {
-        int hooked_add_42(int a) { return add_42_hook.thiscall<int>(this, a) + 1337; }
+        int hooked_add_42(int a) { return add_42_hook->thiscall<int>(this, a) + 1337; }
     };
 
     auto vmt_result = SafetyHookVmt::create(target.get());
@@ -178,7 +190,7 @@ TEST(VmtHook, CanApplyAnExistingVMTHookToMoreThanOneObject) {
 
     ASSERT_TRUE(vm_result.has_value());
 
-    add_42_hook = std::move(*vm_result);
+    add_42_hook_storage = std::move(*vm_result);
 
     target_hook.apply(target0.get());
     target_hook.apply(target1.get());
@@ -189,7 +201,7 @@ TEST(VmtHook, CanApplyAnExistingVMTHookToMoreThanOneObject) {
     EXPECT_EQ(target1->add_42(1), 1380);
     EXPECT_EQ(target2->add_42(1), 1380);
 
-    add_42_hook.reset();
+    add_42_hook_storage.reset();
 
     EXPECT_EQ(target->add_42(2), 44);
     EXPECT_EQ(target0->add_42(2), 44);
@@ -207,11 +219,13 @@ TEST(VmtHook, CanRemoveAnObjectThatWasPreviouslyVMTHooked) {
 
     EXPECT_EQ(target->add_42(0), 42);
 
-    static SafetyHookVmt target_hook{};
-    static SafetyHookVm add_42_hook{};
+    SafetyHookVmt target_hook{};
+    static SafetyHookVm* add_42_hook{};
+    SafetyHookVm add_42_hook_storage{};
+    add_42_hook = &add_42_hook_storage;
 
     struct Hook : SingleTarget {
-        int hooked_add_42(int a) { return add_42_hook.thiscall<int>(this, a) + 1337; }
+        int hooked_add_42(int a) { return add_42_hook->thiscall<int>(this, a) + 1337; }
     };
 
     auto vmt_result = SafetyHookVmt::create(target.get());
@@ -224,7 +238,7 @@ TEST(VmtHook, CanRemoveAnObjectThatWasPreviouslyVMTHooked) {
 
     ASSERT_TRUE(vm_result.has_value());
 
-    add_42_hook = std::move(*vm_result);
+    add_42_hook_storage = std::move(*vm_result);
 
     target_hook.apply(target0.get());
     target_hook.apply(target1.get());
@@ -263,7 +277,7 @@ TEST(VmtHook, CanRemoveAnObjectThatWasPreviouslyVMTHooked) {
     EXPECT_EQ(target1->add_42(2), 44);
     EXPECT_EQ(target2->add_42(2), 44);
 
-    add_42_hook.reset();
+    add_42_hook_storage.reset();
     target_hook.reset();
 }
 
@@ -272,19 +286,21 @@ TEST(VmtHook, VMTHookAnObjectInstanceWithEasyAPI) {
 
     EXPECT_EQ(target->add_42(0), 42);
 
-    static SafetyHookVmt target_hook{};
-    static SafetyHookVm add_42_hook{};
+    SafetyHookVmt target_hook{};
+    static SafetyHookVm* add_42_hook{};
+    SafetyHookVm add_42_hook_storage{};
+    add_42_hook = &add_42_hook_storage;
 
     struct Hook : SingleTarget {
-        int hooked_add_42(int a) { return add_42_hook.thiscall<int>(this, a) + 1337; }
+        int hooked_add_42(int a) { return add_42_hook->thiscall<int>(this, a) + 1337; }
     };
 
     target_hook = safetyhook::create_vmt(target.get());
-    add_42_hook = safetyhook::create_vm(target_hook, 1 + VMT_OFFSET, &Hook::hooked_add_42);
+    add_42_hook_storage = safetyhook::create_vm(target_hook, 1 + VMT_OFFSET, &Hook::hooked_add_42);
 
     EXPECT_EQ(target->add_42(1), 1380);
 
-    add_42_hook.reset();
+    add_42_hook_storage.reset();
 
     EXPECT_EQ(target->add_42(2), 44);
 
@@ -296,11 +312,13 @@ TEST(VmtHook, VMTHookPreservesDynamicCastWithCrossCast) {
 
     CastBase2* base2 = target.get();
 
-    static SafetyHookVmt base2_hook{};
-    static SafetyHookVm add_1337_hook{};
+    SafetyHookVmt base2_hook{};
+    static SafetyHookVm* add_1337_hook{};
+    SafetyHookVm add_1337_hook_storage{};
+    add_1337_hook = &add_1337_hook_storage;
 
     struct Hook : CastTarget {
-        int hooked_add_1337(int a) { return add_1337_hook.thiscall<int>(this, a) + 42; }
+        int hooked_add_1337(int a) { return add_1337_hook->thiscall<int>(this, a) + 42; }
     };
 
     auto vmt_result = SafetyHookVmt::create(base2);
@@ -309,7 +327,7 @@ TEST(VmtHook, VMTHookPreservesDynamicCastWithCrossCast) {
 
     auto vm_result = base2_hook.hook_method(1 + VMT_OFFSET, &Hook::hooked_add_1337);
     ASSERT_TRUE(vm_result.has_value());
-    add_1337_hook = std::move(*vm_result);
+    add_1337_hook_storage = std::move(*vm_result);
 
     EXPECT_EQ(base2->add_1337(1), 1380);
 
@@ -320,6 +338,6 @@ TEST(VmtHook, VMTHookPreservesDynamicCastWithCrossCast) {
     EXPECT_NE(base1, nullptr);
     EXPECT_EQ(base1->add_42(1), 43);
 
-    add_1337_hook.reset();
+    add_1337_hook_storage.reset();
     base2_hook.reset();
 }

--- a/test/vmt_hook.cpp
+++ b/test/vmt_hook.cpp
@@ -1,7 +1,10 @@
 #include <boost/ut.hpp>
 #include <safetyhook.hpp>
 
+#include "vmt_targets.hpp"
+
 using namespace boost::ut;
+using namespace safetyhook::test;
 
 #if SAFETYHOOK_ABI_MSVC
 static constexpr auto VMT_OFFSET = 0;
@@ -11,23 +14,14 @@ static constexpr auto VMT_OFFSET = 1;
 
 static suite<"vmt hook"> vmt_hook_tests = [] {
     "VMT hook an object instance"_test = [] {
-        struct Interface {
-            virtual ~Interface() = default;
-            virtual int add_42(int a) = 0;
-        };
-
-        struct Target : Interface {
-            SAFETYHOOK_NOINLINE int add_42(int a) override { return a + 42; }
-        };
-
-        std::unique_ptr<Interface> target = std::make_unique<Target>();
+        auto target = make_single_target();
 
         expect(target->add_42(0) == 42_i);
 
         static SafetyHookVmt target_hook{};
         static SafetyHookVm add_42_hook{};
 
-        struct Hook : Target {
+        struct Hook : SingleTarget {
             int hooked_add_42(int a) { return add_42_hook.thiscall<int>(this, a) + 1337; }
         };
 
@@ -51,18 +45,7 @@ static suite<"vmt hook"> vmt_hook_tests = [] {
     };
 
     "Resetting the VMT hook removes all VM hooks for that object"_test = [] {
-        struct Interface {
-            virtual ~Interface() = default;
-            virtual int add_42(int a) = 0;
-            virtual int add_43(int a) = 0;
-        };
-
-        struct Target : Interface {
-            SAFETYHOOK_NOINLINE int add_42(int a) override { return a + 42; }
-            SAFETYHOOK_NOINLINE int add_43(int a) override { return a + 43; }
-        };
-
-        std::unique_ptr<Interface> target = std::make_unique<Target>();
+        auto target = make_dual_target();
 
         expect(target->add_42(0) == 42_i);
         expect(target->add_43(0) == 43_i);
@@ -71,7 +54,7 @@ static suite<"vmt hook"> vmt_hook_tests = [] {
         static SafetyHookVm add_42_hook{};
         static SafetyHookVm add_43_hook{};
 
-        struct Hook : Target {
+        struct Hook : DualTarget {
             int hooked_add_42(int a) { return add_42_hook.thiscall<int>(this, a) + 1337; }
             int hooked_add_43(int a) { return add_43_hook.thiscall<int>(this, a) + 1337; }
         };
@@ -105,24 +88,15 @@ static suite<"vmt hook"> vmt_hook_tests = [] {
     };
 
     "VMT hooking an object maintains correct RTTI"_test = [] {
-        struct Interface {
-            virtual ~Interface() = default;
-            virtual int add_42(int a) = 0;
-        };
-
-        struct Target : Interface {
-            SAFETYHOOK_NOINLINE int add_42(int a) override { return a + 42; }
-        };
-
-        auto target = std::make_unique<Target>();
+        auto target = make_single_target();
 
         expect(target->add_42(0) == 42_i);
-        expect(neq(dynamic_cast<Interface*>(target.get()), nullptr));
+        expect(neq(dynamic_cast<SingleInterface*>(target.get()), nullptr));
 
         static SafetyHookVmt target_hook{};
         static SafetyHookVm add_42_hook{};
 
-        struct Hook : Target {
+        struct Hook : SingleTarget {
             int hooked_add_42(int a) { return add_42_hook.thiscall<int>(this, a) + 1337; }
         };
 
@@ -139,27 +113,18 @@ static suite<"vmt hook"> vmt_hook_tests = [] {
         add_42_hook = std::move(*vm_result);
 
         expect(target->add_42(1) == 1380_i);
-        expect(neq(dynamic_cast<Interface*>(target.get()), nullptr));
+        expect(neq(dynamic_cast<SingleInterface*>(target.get()), nullptr));
     };
 
     "Can safely destroy VmtHook after object is deleted"_test = [] {
-        struct Interface {
-            virtual ~Interface() = default;
-            virtual int add_42(int a) = 0;
-        };
-
-        struct Target : Interface {
-            SAFETYHOOK_NOINLINE int add_42(int a) override { return a + 42; }
-        };
-
-        std::unique_ptr<Interface> target = std::make_unique<Target>();
+        auto target = make_single_target();
 
         expect(target->add_42(0) == 42_i);
 
         static SafetyHookVmt target_hook{};
         static SafetyHookVm add_42_hook{};
 
-        struct Hook : Target {
+        struct Hook : SingleTarget {
             int hooked_add_42(int a) { return add_42_hook.thiscall<int>(this, a) + 1337; }
         };
 
@@ -182,26 +147,17 @@ static suite<"vmt hook"> vmt_hook_tests = [] {
     };
 
     "Can apply an existing VMT hook to more than one object"_test = [] {
-        struct Interface {
-            virtual ~Interface() = default;
-            virtual int add_42(int a) = 0;
-        };
-
-        struct Target : Interface {
-            SAFETYHOOK_NOINLINE int add_42(int a) override { return a + 42; }
-        };
-
-        std::unique_ptr<Interface> target = std::make_unique<Target>();
-        std::unique_ptr<Interface> target0 = std::make_unique<Target>();
-        std::unique_ptr<Interface> target1 = std::make_unique<Target>();
-        std::unique_ptr<Interface> target2 = std::make_unique<Target>();
+        auto target = make_single_target();
+        auto target0 = make_single_target();
+        auto target1 = make_single_target();
+        auto target2 = make_single_target();
 
         expect(target->add_42(0) == 42_i);
 
         static SafetyHookVmt target_hook{};
         static SafetyHookVm add_42_hook{};
 
-        struct Hook : Target {
+        struct Hook : SingleTarget {
             int hooked_add_42(int a) { return add_42_hook.thiscall<int>(this, a) + 1337; }
         };
 
@@ -235,26 +191,17 @@ static suite<"vmt hook"> vmt_hook_tests = [] {
     };
 
     "Can remove an object that was previously VMT hooked"_test = [] {
-        struct Interface {
-            virtual ~Interface() = default;
-            virtual int add_42(int a) = 0;
-        };
-
-        struct Target : Interface {
-            SAFETYHOOK_NOINLINE int add_42(int a) override { return a + 42; }
-        };
-
-        std::unique_ptr<Interface> target = std::make_unique<Target>();
-        std::unique_ptr<Interface> target0 = std::make_unique<Target>();
-        std::unique_ptr<Interface> target1 = std::make_unique<Target>();
-        std::unique_ptr<Interface> target2 = std::make_unique<Target>();
+        auto target = make_single_target();
+        auto target0 = make_single_target();
+        auto target1 = make_single_target();
+        auto target2 = make_single_target();
 
         expect(target->add_42(0) == 42_i);
 
         static SafetyHookVmt target_hook{};
         static SafetyHookVm add_42_hook{};
 
-        struct Hook : Target {
+        struct Hook : SingleTarget {
             int hooked_add_42(int a) { return add_42_hook.thiscall<int>(this, a) + 1337; }
         };
 
@@ -309,23 +256,14 @@ static suite<"vmt hook"> vmt_hook_tests = [] {
     };
 
     "VMT hook an object instance with easy API"_test = [] {
-        struct Interface {
-            virtual ~Interface() = default;
-            virtual int add_42(int a) = 0;
-        };
-
-        struct Target : Interface {
-            SAFETYHOOK_NOINLINE int add_42(int a) override { return a + 42; }
-        };
-
-        std::unique_ptr<Interface> target = std::make_unique<Target>();
+        auto target = make_single_target();
 
         expect(target->add_42(0) == 42_i);
 
         static SafetyHookVmt target_hook{};
         static SafetyHookVm add_42_hook{};
 
-        struct Hook : Target {
+        struct Hook : SingleTarget {
             int hooked_add_42(int a) { return add_42_hook.thiscall<int>(this, a) + 1337; }
         };
 
@@ -340,29 +278,14 @@ static suite<"vmt hook"> vmt_hook_tests = [] {
     };
 
     "VMT hook preserves dynamic_cast with cross-cast"_test = [] {
-        struct Base1 {
-            virtual ~Base1() = default;
-            virtual int add_42(int a) = 0;
-        };
+        auto target = make_cast_target();
 
-        struct Base2 {
-            virtual ~Base2() = default;
-            virtual int add_1337(int a) = 0;
-        };
-
-        struct Target : Base1, Base2 {
-            SAFETYHOOK_NOINLINE int add_42(int a) override { return a + 42; }
-            SAFETYHOOK_NOINLINE int add_1337(int a) override { return a + 1337; }
-        };
-
-        auto target = std::make_unique<Target>();
-
-        Base2* base2 = target.get();
+        CastBase2* base2 = target.get();
 
         static SafetyHookVmt base2_hook{};
         static SafetyHookVm add_1337_hook{};
 
-        struct Hook : Target {
+        struct Hook : CastTarget {
             int hooked_add_1337(int a) { return add_1337_hook.thiscall<int>(this, a) + 42; }
         };
 
@@ -376,10 +299,10 @@ static suite<"vmt hook"> vmt_hook_tests = [] {
 
         expect(base2->add_1337(1) == 1380_i);
 
-        // Cross-cast: Base2* -> Base1*
-        // Runtime reads offset-to-top from Base2's vptr[-2]
+        // Cross-cast: CastBase2* -> CastBase1*
+        // Runtime reads offset-to-top from CastBase2's vptr[-2]
         // Without the fix this is garbage and will crash or return wrong pointer
-        Base1* base1 = dynamic_cast<Base1*>(base2);
+        CastBase1* base1 = dynamic_cast<CastBase1*>(base2);
         expect(neq(base1, nullptr));
         expect(base1->add_42(1) == 43_i);
 

--- a/test/vmt_hook.cpp
+++ b/test/vmt_hook.cpp
@@ -42,6 +42,8 @@ static suite<"vmt hook"> vmt_hook_tests = [] {
         add_42_hook.reset();
 
         expect(target->add_42(2) == 44_i);
+
+        target_hook.reset();
     };
 
     "Resetting the VMT hook removes all VM hooks for that object"_test = [] {
@@ -85,6 +87,9 @@ static suite<"vmt hook"> vmt_hook_tests = [] {
 
         expect(target->add_42(2) == 44_i);
         expect(target->add_43(2) == 45_i);
+
+        add_42_hook.reset();
+        add_43_hook.reset();
     };
 
     "VMT hooking an object maintains correct RTTI"_test = [] {
@@ -114,6 +119,9 @@ static suite<"vmt hook"> vmt_hook_tests = [] {
 
         expect(target->add_42(1) == 1380_i);
         expect(neq(dynamic_cast<SingleInterface*>(target.get()), nullptr));
+
+        add_42_hook.reset();
+        target_hook.reset();
     };
 
     "Can safely destroy VmtHook after object is deleted"_test = [] {
@@ -144,6 +152,7 @@ static suite<"vmt hook"> vmt_hook_tests = [] {
 
         target.reset();
         target_hook.reset();
+        add_42_hook.reset();
     };
 
     "Can apply an existing VMT hook to more than one object"_test = [] {
@@ -188,6 +197,8 @@ static suite<"vmt hook"> vmt_hook_tests = [] {
         expect(target0->add_42(2) == 44_i);
         expect(target1->add_42(2) == 44_i);
         expect(target2->add_42(2) == 44_i);
+
+        target_hook.reset();
     };
 
     "Can remove an object that was previously VMT hooked"_test = [] {
@@ -253,6 +264,9 @@ static suite<"vmt hook"> vmt_hook_tests = [] {
         expect(target0->add_42(2) == 44_i);
         expect(target1->add_42(2) == 44_i);
         expect(target2->add_42(2) == 44_i);
+
+        add_42_hook.reset();
+        target_hook.reset();
     };
 
     "VMT hook an object instance with easy API"_test = [] {
@@ -275,6 +289,8 @@ static suite<"vmt hook"> vmt_hook_tests = [] {
         add_42_hook.reset();
 
         expect(target->add_42(2) == 44_i);
+
+        target_hook.reset();
     };
 
     "VMT hook preserves dynamic_cast with cross-cast"_test = [] {

--- a/test/vmt_hook.cpp
+++ b/test/vmt_hook.cpp
@@ -12,7 +12,8 @@ static constexpr auto VMT_OFFSET = 0;
 static constexpr auto VMT_OFFSET = 1;
 #endif
 
-static suite<"vmt hook"> vmt_hook_tests = [] {
+void register_vmt_hook_tests() {
+suite<"vmt hook"> vmt_hook_tests = [] {
     "VMT hook an object instance"_test = [] {
         auto target = make_single_target();
 
@@ -326,3 +327,4 @@ static suite<"vmt hook"> vmt_hook_tests = [] {
         base2_hook.reset();
     };
 };
+}

--- a/test/vmt_targets.cpp
+++ b/test/vmt_targets.cpp
@@ -1,0 +1,18 @@
+#include "vmt_targets.hpp"
+
+// Keep target construction in a separate translation unit so optimized builds
+// cannot devirtualize the VMT hook tests and bypass the replaced vtable.
+
+namespace safetyhook::test {
+std::unique_ptr<SingleInterface> make_single_target() {
+    return std::make_unique<SingleTarget>();
+}
+
+std::unique_ptr<DualInterface> make_dual_target() {
+    return std::make_unique<DualTarget>();
+}
+
+std::unique_ptr<CastTarget> make_cast_target() {
+    return std::make_unique<CastTarget>();
+}
+} // namespace safetyhook::test

--- a/test/vmt_targets.hpp
+++ b/test/vmt_targets.hpp
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <memory>
+
+namespace safetyhook::test {
+struct SingleInterface {
+    virtual ~SingleInterface() = default;
+    virtual int add_42(int a) = 0;
+};
+
+struct SingleTarget : SingleInterface {
+    int add_42(int a) override { return a + 42; }
+};
+
+struct DualInterface {
+    virtual ~DualInterface() = default;
+    virtual int add_42(int a) = 0;
+    virtual int add_43(int a) = 0;
+};
+
+struct DualTarget : DualInterface {
+    int add_42(int a) override { return a + 42; }
+    int add_43(int a) override { return a + 43; }
+};
+
+struct CastBase1 {
+    virtual ~CastBase1() = default;
+    virtual int add_42(int a) = 0;
+};
+
+struct CastBase2 {
+    virtual ~CastBase2() = default;
+    virtual int add_1337(int a) = 0;
+};
+
+struct CastTarget : CastBase1, CastBase2 {
+    int add_42(int a) override { return a + 42; }
+    int add_1337(int a) override { return a + 1337; }
+};
+
+std::unique_ptr<SingleInterface> make_single_target();
+std::unique_ptr<DualInterface> make_dual_target();
+std::unique_ptr<CastTarget> make_cast_target();
+} // namespace safetyhook::test

--- a/test/vmt_targets.hpp
+++ b/test/vmt_targets.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <safetyhook.hpp>
+
 #include <memory>
 
 namespace safetyhook::test {
@@ -9,7 +11,7 @@ struct SingleInterface {
 };
 
 struct SingleTarget : SingleInterface {
-    int add_42(int a) override { return a + 42; }
+    SAFETYHOOK_NOINLINE int add_42(int a) override { return a + 42; }
 };
 
 struct DualInterface {
@@ -19,8 +21,8 @@ struct DualInterface {
 };
 
 struct DualTarget : DualInterface {
-    int add_42(int a) override { return a + 42; }
-    int add_43(int a) override { return a + 43; }
+    SAFETYHOOK_NOINLINE int add_42(int a) override { return a + 42; }
+    SAFETYHOOK_NOINLINE int add_43(int a) override { return a + 43; }
 };
 
 struct CastBase1 {
@@ -34,8 +36,8 @@ struct CastBase2 {
 };
 
 struct CastTarget : CastBase1, CastBase2 {
-    int add_42(int a) override { return a + 42; }
-    int add_1337(int a) override { return a + 1337; }
+    SAFETYHOOK_NOINLINE int add_42(int a) override { return a + 42; }
+    SAFETYHOOK_NOINLINE int add_1337(int a) override { return a + 1337; }
 };
 
 std::unique_ptr<SingleInterface> make_single_target();


### PR DESCRIPTION
## Summary

Expands the CI build matrix beyond the existing Windows MSVC coverage.

The build job now covers:

- Windows MSVC x64 and Win32 in Debug and Release
- Windows clang-cl x64 and Win32 in Debug and Release
- Windows MinGW-w64 x64 in Debug and Release using msys2/setup-msys2
- Linux GCC x64 in Debug and Release
- Linux Clang x64 in Debug and Release

The MinGW rows use the supported MSYS2 GitHub Action path instead of relying on runner-specific PATH setup. Linux and MinGW rows skip examples so the compiler coverage focuses on the library and tests rather than depending on C++23 <print> availability in example programs.

## Validation

- actionlint .github/workflows/build.yml
- git diff --check -- .github/workflows/build.yml