### PR TITLE
Migrate tests to GoogleTest

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -129,7 +129,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v6.0.3
 
       - name: Set up MSYS2
         if: matrix.compiler == 'mingw'
@@ -190,20 +190,18 @@ jobs:
     needs: build
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v6.0.3
 
       - name: Amalgamate
         run: |
-          python3 amalgamate.py
+          python amalgamate.py
 
       - name: Compress amalgamated release
-        uses: vimtor/action-zip@v1.1
-        with:
-          files: amalgamated-dist/
-          dest: safetyhook-amalgamated.zip
+        run: |
+          Compress-Archive -Path amalgamated-dist -DestinationPath safetyhook-amalgamated.zip
 
       - name: Upload amalgamate
-        uses: actions/upload-artifact@v4.3.0
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: safetyhook-amalgamated
           path: amalgamated-dist/
@@ -216,19 +214,17 @@ jobs:
            @("#define ZYCORE_STATIC_BUILD", "#define ZYDIS_STATIC_BUILD") + (Get-Content -Raw .\amalgamated-dist\Zydis.h) | Set-Content -Encoding utf8 .\amalgamated-dist\Zydis.h
 
       - name: Compress amalgamated release with Zydis
-        uses: vimtor/action-zip@v1.1
-        with:
-          files: amalgamated-dist/
-          dest: safetyhook-amalgamated-zydis.zip
+        run: |
+          Compress-Archive -Path amalgamated-dist -DestinationPath safetyhook-amalgamated-zydis.zip
 
       - name: Upload amalgamate with Zydis
-        uses: actions/upload-artifact@v4.3.0
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: safetyhook-amalgamated-zydis
           path: amalgamated-dist/
 
       - name: Release
-        uses: softprops/action-gh-release@v0.1.15
+        uses: softprops/action-gh-release@v3.0.0
         if: startsWith(github.ref, 'refs/tags/')
         with:
           prerelease: ${{contains(github.ref, '-pre')}}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,20 +38,22 @@ project(safetyhook)
 include(FetchContent)
 
 if(SAFETYHOOK_BUILD_TEST) # build-test
-	set(BOOST_UT_DISABLE_MODULE ON CACHE BOOL "" FORCE)
+	set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+	set(INSTALL_GTEST OFF CACHE BOOL "" FORCE)
+	set(BUILD_GMOCK OFF CACHE BOOL "" FORCE)
 
-	message(STATUS "Fetching ut (v2.3.1)...")
-	FetchContent_Declare(ut
+	message(STATUS "Fetching googletest (v1.15.2)...")
+	FetchContent_Declare(googletest
 		GIT_REPOSITORY
-			"https://github.com/boost-ext/ut.git"
+			"https://github.com/google/googletest.git"
 		GIT_TAG
-			v2.3.1
+			v1.15.2
 		GIT_SHALLOW
 			ON
 		EXCLUDE_FROM_ALL
 			ON
 	)
-	FetchContent_MakeAvailable(ut)
+	FetchContent_MakeAvailable(googletest)
 
 endif()
 if(SAFETYHOOK_BUILD_TEST) # build-test
@@ -518,16 +520,12 @@ if(SAFETYHOOK_BUILD_TEST) # build-test
 	target_sources(test PRIVATE ${test_SOURCES})
 	source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} FILES ${test_SOURCES})
 
-	target_compile_definitions(test PRIVATE
-		BOOST_UT_DISABLE_MODULE
-	)
-
 	target_compile_features(test PRIVATE
 		cxx_std_23
 	)
 
 	target_link_libraries(test PRIVATE
-		Boost::ut
+		GTest::gtest
 		safetyhook::safetyhook
 		xbyak::xbyak
 	)
@@ -557,10 +555,6 @@ if(SAFETYHOOK_BUILD_TEST AND SAFETYHOOK_AMALGAMATE) # build-amalgamate-test
 	target_sources(test-amalgamated PRIVATE ${test-amalgamated_SOURCES})
 	source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} FILES ${test-amalgamated_SOURCES})
 
-	target_compile_definitions(test-amalgamated PRIVATE
-		BOOST_UT_DISABLE_MODULE
-	)
-
 	target_compile_features(test-amalgamated PRIVATE
 		cxx_std_23
 	)
@@ -571,7 +565,7 @@ if(SAFETYHOOK_BUILD_TEST AND SAFETYHOOK_AMALGAMATE) # build-amalgamate-test
 
 	target_link_libraries(test-amalgamated PRIVATE
 		Zydis
-		Boost::ut
+		GTest::gtest
 		xbyak::xbyak
 	)
 

--- a/cmake.toml
+++ b/cmake.toml
@@ -26,13 +26,15 @@ fetch-zydis = "SAFETYHOOK_FETCH_ZYDIS"
 find-zydis = "(NOT SAFETYHOOK_FETCH_ZYDIS)"
 build-module = "SAFETYHOOK_BUILD_MODULE"
 
-[fetch-content.ut]
+[fetch-content.googletest]
 condition = "build-test"
-git = "https://github.com/boost-ext/ut.git"
-tag = "v2.3.1"
+git = "https://github.com/google/googletest.git"
+tag = "v1.15.2"
 shallow = true
 cmake-before = """
-set(BOOST_UT_DISABLE_MODULE ON CACHE BOOL "" FORCE)
+set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+set(INSTALL_GTEST OFF CACHE BOOL "" FORCE)
+set(BUILD_GMOCK OFF CACHE BOOL "" FORCE)
 """
 EXCLUDE_FROM_ALL = true
 
@@ -240,8 +242,7 @@ properties.CXX_SCAN_FOR_MODULES = true
 condition = "build-test"
 type = "executable"
 sources = ["test/*.cpp"]
-link-libraries = ["Boost::ut", "safetyhook::safetyhook", "xbyak::xbyak"]
-compile-definitions = ["BOOST_UT_DISABLE_MODULE"]
+link-libraries = ["GTest::gtest", "safetyhook::safetyhook", "xbyak::xbyak"]
 compile-features = ["cxx_std_23"]
 
 [target.test-amalgamated]
@@ -249,8 +250,7 @@ condition = "build-amalgamate-test"
 type = "executable"
 sources = ["test/*.cpp", "amalgamated-dist/safetyhook.cpp"]
 include-directories = ["amalgamated-dist/"]
-link-libraries = ["Zydis", "Boost::ut", "xbyak::xbyak"]
-compile-definitions = ["BOOST_UT_DISABLE_MODULE"]
+link-libraries = ["Zydis", "GTest::gtest", "xbyak::xbyak"]
 compile-features = ["cxx_std_23"]
 cmake-after = """
 add_dependencies(test-amalgamated Amalgamate)

--- a/test/allocator.cpp
+++ b/test/allocator.cpp
@@ -1,33 +1,27 @@
-#include <boost/ut.hpp>
+#include <gtest/gtest.h>
 #include <safetyhook.hpp>
 
-using namespace boost::ut;
+TEST(Allocator, AllocatorReusesFreedMemory) {
+    const auto allocator = safetyhook::Allocator::create();
+    auto first_allocation = allocator->allocate(128);
 
-void register_allocator_tests() {
-suite<"allocator"> allocator_tests = [] {
-    "Allocator reuses freed memory"_test = [] {
-        const auto allocator = safetyhook::Allocator::create();
-        auto first_allocation = allocator->allocate(128);
+    ASSERT_TRUE(first_allocation.has_value());
 
-        expect(first_allocation.has_value());
+    const auto first_allocation_address = first_allocation->address();
+    const auto second_allocation = allocator->allocate(256);
 
-        const auto first_allocation_address = first_allocation->address();
-        const auto second_allocation = allocator->allocate(256);
+    ASSERT_TRUE(second_allocation.has_value());
+    EXPECT_NE(second_allocation->address(), first_allocation_address);
 
-        expect(second_allocation.has_value());
-        expect(neq(second_allocation->address(), first_allocation_address));
+    first_allocation->free();
 
-        first_allocation->free();
+    const auto third_allocation = allocator->allocate(64);
 
-        const auto third_allocation = allocator->allocate(64);
+    ASSERT_TRUE(third_allocation.has_value());
+    EXPECT_EQ(third_allocation->address(), first_allocation_address);
 
-        expect(third_allocation.has_value());
-        expect(eq(third_allocation->address(), first_allocation_address));
+    const auto fourth_allocation = allocator->allocate(64);
 
-        const auto fourth_allocation = allocator->allocate(64);
-
-        expect(fourth_allocation.has_value());
-        expect(eq(fourth_allocation->address(), third_allocation->address() + 64));
-    };
-};
+    ASSERT_TRUE(fourth_allocation.has_value());
+    EXPECT_EQ(fourth_allocation->address(), third_allocation->address() + 64);
 }

--- a/test/inline_hook.cpp
+++ b/test/inline_hook.cpp
@@ -1,3 +1,4 @@
+#include <atomic>
 #include <chrono>
 #include <thread>
 
@@ -110,15 +111,31 @@ TEST(InlineHook, FunctionWithMultipleArgsHooked) {
 
 #if SAFETYHOOK_OS_WINDOWS
 TEST(InlineHook, ActiveFunctionIsHookedAndUnhooked) {
-    static int count = 0;
-    static bool is_running = true;
+    static std::atomic<int> count = 0;
+    static std::atomic<bool> is_running = true;
+    static std::atomic<bool> pause_worker = false;
+    static std::atomic<bool> worker_paused = false;
+
+    count.store(0, std::memory_order_relaxed);
+    is_running.store(true, std::memory_order_relaxed);
+    pause_worker.store(false, std::memory_order_relaxed);
+    worker_paused.store(false, std::memory_order_relaxed);
 
     struct Target {
         SAFETYHOOK_NOINLINE static std::string say_hello(int times) { return "Hello #" + std::to_string(times); }
 
         static void say_hello_infinitely() {
-            while (is_running) {
-                say_hello(count++);
+            while (is_running.load(std::memory_order_relaxed)) {
+                if (pause_worker.load(std::memory_order_acquire)) {
+                    worker_paused.store(true, std::memory_order_release);
+                    while (pause_worker.load(std::memory_order_acquire) && is_running.load(std::memory_order_relaxed)) {
+                        std::this_thread::yield();
+                    }
+                    worker_paused.store(false, std::memory_order_release);
+                    continue;
+                }
+
+                say_hello(count.fetch_add(1, std::memory_order_relaxed));
             }
         }
     };
@@ -127,28 +144,48 @@ TEST(InlineHook, ActiveFunctionIsHookedAndUnhooked) {
 
     std::this_thread::sleep_for(1s);
 
+    // This test hooks code in the same image as safetyhook, which makes trap_threads keep the page executable.
+    // Pause the worker while patching so the test does not race instruction writes. Hooking other images does not
+    // need this manual synchronization because thread trapping redirects execution during the patch window.
+    pause_worker.store(true, std::memory_order_release);
+
+    while (!worker_paused.load(std::memory_order_acquire)) {
+        std::this_thread::yield();
+    }
+
     static SafetyHookInline hook;
 
     struct Hook {
         static std::string say_hello(int times [[maybe_unused]]) { return hook.call<std::string>(1337); }
     };
 
-    auto hook_result = SafetyHookInline::create(Target::say_hello, Hook::say_hello);
+    auto hook_result = SafetyHookInline::create(Target::say_hello, Hook::say_hello, SafetyHookInline::StartDisabled);
 
     ASSERT_TRUE(hook_result.has_value());
 
     hook = std::move(*hook_result);
 
+    ASSERT_TRUE(hook.enable().has_value());
+    pause_worker.store(false, std::memory_order_release);
+
     EXPECT_EQ(Target::say_hello(0), "Hello #1337"sv);
 
     std::this_thread::sleep_for(1s);
+
+    pause_worker.store(true, std::memory_order_release);
+
+    while (!worker_paused.load(std::memory_order_acquire)) {
+        std::this_thread::yield();
+    }
+
     hook.reset();
 
-    is_running = false;
+    is_running.store(false, std::memory_order_relaxed);
+    pause_worker.store(false, std::memory_order_release);
     t.join();
 
     EXPECT_EQ(Target::say_hello(0), "Hello #0"sv);
-    EXPECT_GT(count, 0);
+    EXPECT_GT(count.load(std::memory_order_relaxed), 0);
 }
 #endif
 

--- a/test/inline_hook.cpp
+++ b/test/inline_hook.cpp
@@ -1,5 +1,7 @@
 #include <atomic>
 #include <chrono>
+#include <string>
+#include <string_view>
 #include <thread>
 
 #include <gtest/gtest.h>
@@ -159,13 +161,27 @@ TEST(InlineHook, ActiveFunctionIsHookedAndUnhooked) {
         static std::string say_hello(int times [[maybe_unused]]) { return hook.call<std::string>(1337); }
     };
 
+    const auto stop_worker = [&] {
+        is_running.store(false, std::memory_order_relaxed);
+        pause_worker.store(false, std::memory_order_release);
+        if (t.joinable()) {
+            t.join();
+        }
+    };
+
     auto hook_result = SafetyHookInline::create(Target::say_hello, Hook::say_hello, SafetyHookInline::StartDisabled);
 
-    ASSERT_TRUE(hook_result.has_value());
+    if (!hook_result.has_value()) {
+        stop_worker();
+        FAIL() << "Failed to create inline hook.";
+    }
 
     hook = std::move(*hook_result);
 
-    ASSERT_TRUE(hook.enable().has_value());
+    if (!hook.enable().has_value()) {
+        stop_worker();
+        FAIL() << "Failed to enable inline hook.";
+    }
     pause_worker.store(false, std::memory_order_release);
 
     EXPECT_EQ(Target::say_hello(0), "Hello #1337"sv);
@@ -180,9 +196,7 @@ TEST(InlineHook, ActiveFunctionIsHookedAndUnhooked) {
 
     hook.reset();
 
-    is_running.store(false, std::memory_order_relaxed);
-    pause_worker.store(false, std::memory_order_release);
-    t.join();
+    stop_worker();
 
     EXPECT_EQ(Target::say_hello(0), "Hello #0"sv);
     EXPECT_GT(count.load(std::memory_order_relaxed), 0);

--- a/test/inline_hook.cpp
+++ b/test/inline_hook.cpp
@@ -1,675 +1,687 @@
+#include <chrono>
 #include <thread>
 
-#include <boost/ut.hpp>
+#include <gtest/gtest.h>
 #include <safetyhook.hpp>
 #include <xbyak/xbyak.h>
 
 using namespace std::literals;
-using namespace boost::ut;
 using namespace Xbyak::util;
 
-void register_inline_hook_tests() {
-suite<"inline hook"> inline_hook_tests = [] {
-    "Function hooked multiple times"_test = [] {
-        struct Target {
-            SAFETYHOOK_NOINLINE static std::string fn(std::string name) { return "hello " + name; }
-        };
-
-        expect(eq(Target::fn("world"), "hello world"sv));
-
-        // First hook.
-        static SafetyHookInline hook0;
-
-        struct Hook0 {
-            static std::string fn(std::string name) { return hook0.call<std::string>(name + " and bob"); }
-        };
-
-        auto hook0_result = SafetyHookInline::create(Target::fn, Hook0::fn);
-
-        expect(hook0_result.has_value());
-
-        hook0 = std::move(*hook0_result);
-
-        expect(eq(Target::fn("world"), "hello world and bob"sv));
-
-        // Second hook.
-        static SafetyHookInline hook1;
-
-        struct Hook1 {
-            static std::string fn(std::string name) { return hook1.call<std::string>(name + " and alice"); }
-        };
-
-        auto hook1_result = SafetyHookInline::create(Target::fn, Hook1::fn);
-
-        expect(hook1_result.has_value());
-
-        hook1 = std::move(*hook1_result);
-
-        expect(eq(Target::fn("world"), "hello world and alice and bob"sv));
-
-        // Third hook.
-        static SafetyHookInline hook2;
-
-        struct Hook2 {
-            static std::string fn(std::string name) { return hook2.call<std::string>(name + " and eve"); }
-        };
-
-        auto hook2_result = SafetyHookInline::create(Target::fn, Hook2::fn);
-
-        expect(hook2_result.has_value());
-
-        hook2 = std::move(*hook2_result);
-
-        expect(eq(Target::fn("world"), "hello world and eve and alice and bob"sv));
-
-        // Fourth hook.
-        static SafetyHookInline hook3;
-
-        struct Hook3 {
-            static std::string fn(std::string name) { return hook3.call<std::string>(name + " and carol"); }
-        };
-
-        auto hook3_result = SafetyHookInline::create(Target::fn, Hook3::fn);
-
-        expect(hook3_result.has_value());
-
-        hook3 = std::move(*hook3_result);
-
-        expect(eq(Target::fn("world"), "hello world and carol and eve and alice and bob"sv));
-
-        // Unhook.
-        hook3.reset();
-        hook2.reset();
-        hook1.reset();
-        hook0.reset();
+TEST(InlineHook, FunctionHookedMultipleTimes) {
+    struct Target {
+        SAFETYHOOK_NOINLINE static std::string fn(std::string name) { return "hello " + name; }
     };
 
-    "Function with multiple args hooked"_test = [] {
-        struct Target {
-            SAFETYHOOK_NOINLINE static int add(int x, int y) { return x + y; }
-        };
+    EXPECT_EQ(Target::fn("world"), "hello world"sv);
 
-        expect(Target::add(2, 3) == 5_i);
+    // First hook.
+    static SafetyHookInline hook0;
 
-        static SafetyHookInline add_hook;
-
-        struct AddHook {
-            static int add(int x, int y) { return add_hook.call<int>(x * 2, y * 2); }
-        };
-
-        auto add_hook_result = SafetyHookInline::create(Target::add, AddHook::add);
-
-        expect(add_hook_result.has_value());
-
-        add_hook = std::move(*add_hook_result);
-
-        expect(Target::add(3, 4) == 14_i);
-
-        add_hook.reset();
-
-        expect(Target::add(5, 6) == 11_i);
+    struct Hook0 {
+        static std::string fn(std::string name) { return hook0.call<std::string>(name + " and bob"); }
     };
+
+    auto hook0_result = SafetyHookInline::create(Target::fn, Hook0::fn);
+
+    ASSERT_TRUE(hook0_result.has_value());
+
+    hook0 = std::move(*hook0_result);
+
+    EXPECT_EQ(Target::fn("world"), "hello world and bob"sv);
+
+    // Second hook.
+    static SafetyHookInline hook1;
+
+    struct Hook1 {
+        static std::string fn(std::string name) { return hook1.call<std::string>(name + " and alice"); }
+    };
+
+    auto hook1_result = SafetyHookInline::create(Target::fn, Hook1::fn);
+
+    ASSERT_TRUE(hook1_result.has_value());
+
+    hook1 = std::move(*hook1_result);
+
+    EXPECT_EQ(Target::fn("world"), "hello world and alice and bob"sv);
+
+    // Third hook.
+    static SafetyHookInline hook2;
+
+    struct Hook2 {
+        static std::string fn(std::string name) { return hook2.call<std::string>(name + " and eve"); }
+    };
+
+    auto hook2_result = SafetyHookInline::create(Target::fn, Hook2::fn);
+
+    ASSERT_TRUE(hook2_result.has_value());
+
+    hook2 = std::move(*hook2_result);
+
+    EXPECT_EQ(Target::fn("world"), "hello world and eve and alice and bob"sv);
+
+    // Fourth hook.
+    static SafetyHookInline hook3;
+
+    struct Hook3 {
+        static std::string fn(std::string name) { return hook3.call<std::string>(name + " and carol"); }
+    };
+
+    auto hook3_result = SafetyHookInline::create(Target::fn, Hook3::fn);
+
+    ASSERT_TRUE(hook3_result.has_value());
+
+    hook3 = std::move(*hook3_result);
+
+    EXPECT_EQ(Target::fn("world"), "hello world and carol and eve and alice and bob"sv);
+
+    // Unhook.
+    hook3.reset();
+    hook2.reset();
+    hook1.reset();
+    hook0.reset();
+}
+
+TEST(InlineHook, FunctionWithMultipleArgsHooked) {
+    struct Target {
+        SAFETYHOOK_NOINLINE static int add(int x, int y) { return x + y; }
+    };
+
+    EXPECT_EQ(Target::add(2, 3), 5);
+
+    static SafetyHookInline add_hook;
+
+    struct AddHook {
+        static int add(int x, int y) { return add_hook.call<int>(x * 2, y * 2); }
+    };
+
+    auto add_hook_result = SafetyHookInline::create(Target::add, AddHook::add);
+
+    ASSERT_TRUE(add_hook_result.has_value());
+
+    add_hook = std::move(*add_hook_result);
+
+    EXPECT_EQ(Target::add(3, 4), 14);
+
+    add_hook.reset();
+
+    EXPECT_EQ(Target::add(5, 6), 11);
+}
 
 #if SAFETYHOOK_OS_WINDOWS
-    "Active function is hooked and unhooked"_test = [] {
-        static int count = 0;
-        static bool is_running = true;
+TEST(InlineHook, ActiveFunctionIsHookedAndUnhooked) {
+    static int count = 0;
+    static bool is_running = true;
 
-        struct Target {
-            SAFETYHOOK_NOINLINE static std::string say_hello(int times) { return "Hello #" + std::to_string(times); }
+    struct Target {
+        SAFETYHOOK_NOINLINE static std::string say_hello(int times) { return "Hello #" + std::to_string(times); }
 
-            static void say_hello_infinitely() {
-                while (is_running) {
-                    say_hello(count++);
-                }
+        static void say_hello_infinitely() {
+            while (is_running) {
+                say_hello(count++);
             }
-        };
-
-        std::thread t{Target::say_hello_infinitely};
-
-        std::this_thread::sleep_for(1s);
-
-        static SafetyHookInline hook;
-
-        struct Hook {
-            static std::string say_hello(int times [[maybe_unused]]) { return hook.call<std::string>(1337); }
-        };
-
-        auto hook_result = SafetyHookInline::create(Target::say_hello, Hook::say_hello);
-
-        expect(hook_result.has_value());
-
-        hook = std::move(*hook_result);
-
-        expect(eq(Target::say_hello(0), "Hello #1337"sv));
-
-        std::this_thread::sleep_for(1s);
-        hook.reset();
-
-        is_running = false;
-        t.join();
-
-        expect(eq(Target::say_hello(0), "Hello #0"sv));
-        expect(count > 0_i);
+        }
     };
+
+    std::thread t{Target::say_hello_infinitely};
+
+    std::this_thread::sleep_for(1s);
+
+    static SafetyHookInline hook;
+
+    struct Hook {
+        static std::string say_hello(int times [[maybe_unused]]) { return hook.call<std::string>(1337); }
+    };
+
+    auto hook_result = SafetyHookInline::create(Target::say_hello, Hook::say_hello);
+
+    ASSERT_TRUE(hook_result.has_value());
+
+    hook = std::move(*hook_result);
+
+    EXPECT_EQ(Target::say_hello(0), "Hello #1337"sv);
+
+    std::this_thread::sleep_for(1s);
+    hook.reset();
+
+    is_running = false;
+    t.join();
+
+    EXPECT_EQ(Target::say_hello(0), "Hello #0"sv);
+    EXPECT_GT(count, 0);
+}
 #endif
 
-    "Function with short unconditional branch is hooked"_test = [] {
-        static SafetyHookInline hook;
+TEST(InlineHook, FunctionWithShortUnconditionalBranchIsHooked) {
+    static SafetyHookInline hook;
 
-        struct Hook {
-            static int SAFETYHOOK_FASTCALL fn() { return hook.fastcall<int>() + 42; };
-        };
+    struct Hook {
+        static int SAFETYHOOK_FASTCALL fn() { return hook.fastcall<int>() + 42; };
+    };
 
-        Xbyak::CodeGenerator cg{};
+    Xbyak::CodeGenerator cg{};
 
-        cg.jmp("@f");
+    cg.jmp("@f");
+    cg.mov(eax, 0);
+    cg.ret();
+    cg.nop(10, false);
+    cg.L("@@");
+    cg.mov(eax, 1);
+    cg.ret();
+    cg.nop(10, false);
+
+    const auto fn = cg.getCode<int(SAFETYHOOK_FASTCALL*)()>();
+
+    EXPECT_EQ(fn(), 1);
+
+    hook = safetyhook::create_inline(fn, Hook::fn);
+
+    EXPECT_EQ(fn(), 43);
+
+    hook.reset();
+
+    EXPECT_EQ(fn(), 1);
+}
+
+TEST(InlineHook, FunctionWithShortConditionalBranchIsHooked) {
+    static SafetyHookInline hook;
+
+    struct Hook {
+        static int SAFETYHOOK_FASTCALL fn(int x) { return hook.fastcall<int>(x) + 42; };
+    };
+
+    Xbyak::CodeGenerator cg{};
+    Xbyak::Label label{};
+    const auto finalize = [&cg, &label] {
         cg.mov(eax, 0);
         cg.ret();
         cg.nop(10, false);
-        cg.L("@@");
+        cg.L(label);
         cg.mov(eax, 1);
         cg.ret();
         cg.nop(10, false);
-
-        const auto fn = cg.getCode<int(SAFETYHOOK_FASTCALL*)()>();
-
-        expect(fn() == 1_i);
-
-        hook = safetyhook::create_inline(fn, Hook::fn);
-
-        expect(fn() == 43_i);
-
-        hook.reset();
-
-        expect(fn() == 1_i);
+        return cg.getCode<int(SAFETYHOOK_FASTCALL*)(int)>();
     };
-
-    "Function with short conditional branch is hooked"_test = [] {
-        static SafetyHookInline hook;
-
-        struct Hook {
-            static int SAFETYHOOK_FASTCALL fn(int x) { return hook.fastcall<int>(x) + 42; };
-        };
-
-        Xbyak::CodeGenerator cg{};
-        Xbyak::Label label{};
-        const auto finalize = [&cg, &label] {
-            cg.mov(eax, 0);
-            cg.ret();
-            cg.nop(10, false);
-            cg.L(label);
-            cg.mov(eax, 1);
-            cg.ret();
-            cg.nop(10, false);
-            return cg.getCode<int(SAFETYHOOK_FASTCALL*)(int)>();
-        };
 
 #if SAFETYHOOK_OS_WINDOWS
-        constexpr auto param = ecx;
+    constexpr auto param = ecx;
 #elif SAFETYHOOK_OS_LINUX
-        constexpr auto param = edi;
+    constexpr auto param = edi;
 #endif
 
-        "JB"_test = [&] {
-            cg.cmp(param, 8);
-            cg.jb(label);
-            const auto fn = finalize();
-
-            expect(fn(7) == 1_i);
-            expect(fn(8) == 0_i);
-            expect(fn(9) == 0_i);
-
-            hook = safetyhook::create_inline(fn, Hook::fn);
-
-            expect(fn(7) == 43_i);
-            expect(fn(8) == 42_i);
-            expect(fn(9) == 42_i);
-
-            hook.reset();
-
-            expect(fn(7) == 1_i);
-            expect(fn(8) == 0_i);
-            expect(fn(9) == 0_i);
-
-            cg.reset();
-        };
-
-        "JBE"_test = [&] {
-            cg.cmp(param, 8);
-            cg.jbe(label);
-            const auto fn = finalize();
-
-            expect(fn(7) == 1_i);
-            expect(fn(8) == 1_i);
-            expect(fn(9) == 0_i);
-
-            hook = safetyhook::create_inline(fn, Hook::fn);
-
-            expect(fn(7) == 43_i);
-            expect(fn(8) == 43_i);
-            expect(fn(9) == 42_i);
-
-            hook.reset();
-
-            expect(fn(7) == 1_i);
-            expect(fn(8) == 1_i);
-            expect(fn(9) == 0_i);
-
-            cg.reset();
-        };
-
-        "JL"_test = [&] {
-            cg.cmp(param, 8);
-            cg.jl(label);
-            const auto fn = finalize();
-
-            expect(fn(7) == 1_i);
-            expect(fn(8) == 0_i);
-            expect(fn(9) == 0_i);
-
-            hook = safetyhook::create_inline(fn, Hook::fn);
-
-            expect(fn(7) == 43_i);
-            expect(fn(8) == 42_i);
-            expect(fn(9) == 42_i);
-
-            hook.reset();
-
-            expect(fn(7) == 1_i);
-            expect(fn(8) == 0_i);
-            expect(fn(9) == 0_i);
-
-            cg.reset();
-        };
-
-        "JLE"_test = [&] {
-            cg.cmp(param, 8);
-            cg.jle(label);
-            const auto fn = finalize();
-
-            expect(fn(7) == 1_i);
-            expect(fn(8) == 1_i);
-            expect(fn(9) == 0_i);
-
-            hook = safetyhook::create_inline(fn, Hook::fn);
-
-            expect(fn(7) == 43_i);
-            expect(fn(8) == 43_i);
-            expect(fn(9) == 42_i);
-
-            hook.reset();
-
-            expect(fn(7) == 1_i);
-            expect(fn(8) == 1_i);
-            expect(fn(9) == 0_i);
-
-            cg.reset();
-        };
-
-        "JNB"_test = [&] {
-            cg.cmp(param, 8);
-            cg.jnb(label);
-            const auto fn = finalize();
-
-            expect(fn(7) == 0_i);
-            expect(fn(8) == 1_i);
-            expect(fn(9) == 1_i);
-
-            hook = safetyhook::create_inline(fn, Hook::fn);
-
-            expect(fn(7) == 42_i);
-            expect(fn(8) == 43_i);
-            expect(fn(9) == 43_i);
-
-            hook.reset();
-
-            expect(fn(7) == 0_i);
-            expect(fn(8) == 1_i);
-            expect(fn(9) == 1_i);
-
-            cg.reset();
-        };
-
-        "JNBE"_test = [&] {
-            cg.cmp(param, 8);
-            cg.jnbe(label);
-            const auto fn = finalize();
-
-            expect(fn(7) == 0_i);
-            expect(fn(8) == 0_i);
-            expect(fn(9) == 1_i);
-
-            hook = safetyhook::create_inline(fn, Hook::fn);
-
-            expect(fn(7) == 42_i);
-            expect(fn(8) == 42_i);
-            expect(fn(9) == 43_i);
-
-            hook.reset();
-
-            expect(fn(7) == 0_i);
-            expect(fn(8) == 0_i);
-            expect(fn(9) == 1_i);
-
-            cg.reset();
-        };
-
-        "JNL"_test = [&] {
-            cg.cmp(param, 8);
-            cg.jnl(label);
-            const auto fn = finalize();
-
-            expect(fn(7) == 0_i);
-            expect(fn(8) == 1_i);
-            expect(fn(9) == 1_i);
-
-            hook = safetyhook::create_inline(fn, Hook::fn);
-
-            expect(fn(7) == 42_i);
-            expect(fn(8) == 43_i);
-            expect(fn(9) == 43_i);
-
-            hook.reset();
-
-            expect(fn(7) == 0_i);
-            expect(fn(8) == 1_i);
-            expect(fn(9) == 1_i);
-
-            cg.reset();
-        };
-
-        "JNLE"_test = [&] {
-            cg.cmp(param, 8);
-            cg.jnle(label);
-            const auto fn = finalize();
-
-            expect(fn(7) == 0_i);
-            expect(fn(8) == 0_i);
-            expect(fn(9) == 1_i);
-
-            hook = safetyhook::create_inline(fn, Hook::fn);
-
-            expect(fn(7) == 42_i);
-            expect(fn(8) == 42_i);
-            expect(fn(9) == 43_i);
-
-            hook.reset();
-
-            expect(fn(7) == 0_i);
-            expect(fn(8) == 0_i);
-            expect(fn(9) == 1_i);
-
-            cg.reset();
-        };
-
-        "JNO"_test = [&] {
-            cg.cmp(param, 8);
-            cg.jno(label);
-            const auto fn = finalize();
-
-            expect(fn(7) == 1_i);
-            expect(fn(8) == 1_i);
-            expect(fn(9) == 1_i);
-
-            hook = safetyhook::create_inline(fn, Hook::fn);
-
-            expect(fn(7) == 43_i);
-            expect(fn(8) == 43_i);
-            expect(fn(9) == 43_i);
-
-            hook.reset();
-
-            expect(fn(7) == 1_i);
-            expect(fn(8) == 1_i);
-            expect(fn(9) == 1_i);
-
-            cg.reset();
-        };
-
-        "JNP"_test = [&] {
-            cg.cmp(param, 8);
-            cg.jnp(label);
-            const auto fn = finalize();
-
-            expect(fn(7) == 0_i);
-            expect(fn(8) == 0_i);
-            expect(fn(9) == 1_i);
-
-            hook = safetyhook::create_inline(fn, Hook::fn);
-
-            expect(fn(7) == 42_i);
-            expect(fn(8) == 42_i);
-            expect(fn(9) == 43_i);
-
-            hook.reset();
-
-            expect(fn(7) == 0_i);
-            expect(fn(8) == 0_i);
-            expect(fn(9) == 1_i);
-
-            cg.reset();
-        };
-
-        "JNS"_test = [&] {
-            cg.cmp(param, 8);
-            cg.jns(label);
-            const auto fn = finalize();
-
-            expect(fn(7) == 0_i);
-            expect(fn(8) == 1_i);
-            expect(fn(9) == 1_i);
-
-            hook = safetyhook::create_inline(fn, Hook::fn);
-
-            expect(fn(7) == 42_i);
-            expect(fn(8) == 43_i);
-            expect(fn(9) == 43_i);
-
-            hook.reset();
-
-            expect(fn(7) == 0_i);
-            expect(fn(8) == 1_i);
-            expect(fn(9) == 1_i);
-
-            cg.reset();
-        };
-
-        "JNZ"_test = [&] {
-            cg.cmp(param, 8);
-            cg.jnz(label);
-            const auto fn = finalize();
-
-            expect(fn(7) == 1_i);
-            expect(fn(8) == 0_i);
-            expect(fn(9) == 1_i);
-
-            hook = safetyhook::create_inline(fn, Hook::fn);
-
-            expect(fn(7) == 43_i);
-            expect(fn(8) == 42_i);
-            expect(fn(9) == 43_i);
-
-            hook.reset();
-
-            expect(fn(7) == 1_i);
-            expect(fn(8) == 0_i);
-            expect(fn(9) == 1_i);
-
-            cg.reset();
-        };
-
-        "JO"_test = [&] {
-            cg.cmp(param, 8);
-            cg.jo(label);
-            const auto fn = finalize();
-
-            expect(fn(7) == 0_i);
-            expect(fn(8) == 0_i);
-            expect(fn(9) == 0_i);
-
-            hook = safetyhook::create_inline(fn, Hook::fn);
-
-            expect(fn(7) == 42_i);
-            expect(fn(8) == 42_i);
-            expect(fn(9) == 42_i);
-
-            hook.reset();
-
-            expect(fn(7) == 0_i);
-            expect(fn(8) == 0_i);
-            expect(fn(9) == 0_i);
-
-            cg.reset();
-        };
-
-        "JP"_test = [&] {
-            cg.cmp(param, 8);
-            cg.jp(label);
-            const auto fn = finalize();
-
-            expect(fn(7) == 1_i);
-            expect(fn(8) == 1_i);
-            expect(fn(9) == 0_i);
-
-            hook = safetyhook::create_inline(fn, Hook::fn);
-
-            expect(fn(7) == 43_i);
-            expect(fn(8) == 43_i);
-            expect(fn(9) == 42_i);
-
-            hook.reset();
-
-            expect(fn(7) == 1_i);
-            expect(fn(8) == 1_i);
-            expect(fn(9) == 0_i);
-
-            cg.reset();
-        };
-
-        "JS"_test = [&] {
-            cg.cmp(param, 8);
-            cg.js(label);
-            const auto fn = finalize();
-
-            expect(fn(7) == 1_i);
-            expect(fn(8) == 0_i);
-            expect(fn(9) == 0_i);
-
-            hook = safetyhook::create_inline(fn, Hook::fn);
-
-            expect(fn(7) == 43_i);
-            expect(fn(8) == 42_i);
-            expect(fn(9) == 42_i);
-
-            hook.reset();
-
-            expect(fn(7) == 1_i);
-            expect(fn(8) == 0_i);
-            expect(fn(9) == 0_i);
-
-            cg.reset();
-        };
-
-        "JZ"_test = [&] {
-            cg.cmp(param, 8);
-            cg.jz(label);
-            const auto fn = finalize();
-
-            expect(fn(7) == 0_i);
-            expect(fn(8) == 1_i);
-            expect(fn(9) == 0_i);
-
-            hook = safetyhook::create_inline(fn, Hook::fn);
-
-            expect(fn(7) == 42_i);
-            expect(fn(8) == 43_i);
-            expect(fn(9) == 42_i);
-
-            hook.reset();
-
-            expect(fn(7) == 0_i);
-            expect(fn(8) == 1_i);
-            expect(fn(9) == 0_i);
-
-            cg.reset();
-        };
-    };
-
-    "Function with short jump inside trampoline"_test = [] {
-        Xbyak::CodeGenerator cg{};
-
-        cg.jmp("@f");
-        cg.ret();
-        cg.L("@@");
-        cg.mov(eax, 42);
-        cg.ret();
-        cg.nop(10, false);
-
-        const auto fn = cg.getCode<int (*)()>();
-
-        expect(fn() == 42_i);
-
-        static SafetyHookInline hook;
-
-        struct Hook {
-            static int fn() { return hook.call<int>() + 1; }
-        };
+    SCOPED_TRACE("JB");
+    {
+        cg.cmp(param, 8);
+        cg.jb(label);
+        const auto fn = finalize();
+
+        EXPECT_EQ(fn(7), 1);
+        EXPECT_EQ(fn(8), 0);
+        EXPECT_EQ(fn(9), 0);
 
         hook = safetyhook::create_inline(fn, Hook::fn);
 
-        expect(fn() == 43_i);
+        EXPECT_EQ(fn(7), 43);
+        EXPECT_EQ(fn(8), 42);
+        EXPECT_EQ(fn(9), 42);
 
         hook.reset();
 
-        expect(fn() == 42_i);
-    };
+        EXPECT_EQ(fn(7), 1);
+        EXPECT_EQ(fn(8), 0);
+        EXPECT_EQ(fn(9), 0);
 
-    "Function hook can be enable and disabled"_test = [] {
-        struct Target {
-            SAFETYHOOK_NOINLINE static int fn(int a) {
-                volatile int b = a;
-                return b * 2;
-            }
-        };
+        cg.reset();
+    }
 
-        expect(Target::fn(1) == 2_i);
-        expect(Target::fn(2) == 4_i);
-        expect(Target::fn(3) == 6_i);
+    SCOPED_TRACE("JBE");
+    {
+        cg.cmp(param, 8);
+        cg.jbe(label);
+        const auto fn = finalize();
 
-        static SafetyHookInline hook;
+        EXPECT_EQ(fn(7), 1);
+        EXPECT_EQ(fn(8), 1);
+        EXPECT_EQ(fn(9), 0);
 
-        struct Hook {
-            static int fn(int a) { return hook.call<int>(a + 1); }
-        };
+        hook = safetyhook::create_inline(fn, Hook::fn);
 
-        auto hook0_result = SafetyHookInline::create(Target::fn, Hook::fn, SafetyHookInline::StartDisabled);
-
-        expect(hook0_result.has_value());
-
-        hook = std::move(*hook0_result);
-
-        expect(Target::fn(1) == 2_i);
-        expect(Target::fn(2) == 4_i);
-        expect(Target::fn(3) == 6_i);
-
-        expect(hook.enable().has_value());
-
-        expect(Target::fn(1) == 4_i);
-        expect(Target::fn(2) == 6_i);
-        expect(Target::fn(3) == 8_i);
-
-        expect(hook.disable().has_value());
-
-        expect(Target::fn(1) == 2_i);
-        expect(Target::fn(2) == 4_i);
-        expect(Target::fn(3) == 6_i);
+        EXPECT_EQ(fn(7), 43);
+        EXPECT_EQ(fn(8), 43);
+        EXPECT_EQ(fn(9), 42);
 
         hook.reset();
 
-        expect(Target::fn(1) == 2_i);
-        expect(Target::fn(2) == 4_i);
-        expect(Target::fn(3) == 6_i);
+        EXPECT_EQ(fn(7), 1);
+        EXPECT_EQ(fn(8), 1);
+        EXPECT_EQ(fn(9), 0);
+
+        cg.reset();
+    }
+
+    SCOPED_TRACE("JL");
+    {
+        cg.cmp(param, 8);
+        cg.jl(label);
+        const auto fn = finalize();
+
+        EXPECT_EQ(fn(7), 1);
+        EXPECT_EQ(fn(8), 0);
+        EXPECT_EQ(fn(9), 0);
+
+        hook = safetyhook::create_inline(fn, Hook::fn);
+
+        EXPECT_EQ(fn(7), 43);
+        EXPECT_EQ(fn(8), 42);
+        EXPECT_EQ(fn(9), 42);
+
+        hook.reset();
+
+        EXPECT_EQ(fn(7), 1);
+        EXPECT_EQ(fn(8), 0);
+        EXPECT_EQ(fn(9), 0);
+
+        cg.reset();
+    }
+
+    SCOPED_TRACE("JLE");
+    {
+        cg.cmp(param, 8);
+        cg.jle(label);
+        const auto fn = finalize();
+
+        EXPECT_EQ(fn(7), 1);
+        EXPECT_EQ(fn(8), 1);
+        EXPECT_EQ(fn(9), 0);
+
+        hook = safetyhook::create_inline(fn, Hook::fn);
+
+        EXPECT_EQ(fn(7), 43);
+        EXPECT_EQ(fn(8), 43);
+        EXPECT_EQ(fn(9), 42);
+
+        hook.reset();
+
+        EXPECT_EQ(fn(7), 1);
+        EXPECT_EQ(fn(8), 1);
+        EXPECT_EQ(fn(9), 0);
+
+        cg.reset();
+    }
+
+    SCOPED_TRACE("JNB");
+    {
+        cg.cmp(param, 8);
+        cg.jnb(label);
+        const auto fn = finalize();
+
+        EXPECT_EQ(fn(7), 0);
+        EXPECT_EQ(fn(8), 1);
+        EXPECT_EQ(fn(9), 1);
+
+        hook = safetyhook::create_inline(fn, Hook::fn);
+
+        EXPECT_EQ(fn(7), 42);
+        EXPECT_EQ(fn(8), 43);
+        EXPECT_EQ(fn(9), 43);
+
+        hook.reset();
+
+        EXPECT_EQ(fn(7), 0);
+        EXPECT_EQ(fn(8), 1);
+        EXPECT_EQ(fn(9), 1);
+
+        cg.reset();
+    }
+
+    SCOPED_TRACE("JNBE");
+    {
+        cg.cmp(param, 8);
+        cg.jnbe(label);
+        const auto fn = finalize();
+
+        EXPECT_EQ(fn(7), 0);
+        EXPECT_EQ(fn(8), 0);
+        EXPECT_EQ(fn(9), 1);
+
+        hook = safetyhook::create_inline(fn, Hook::fn);
+
+        EXPECT_EQ(fn(7), 42);
+        EXPECT_EQ(fn(8), 42);
+        EXPECT_EQ(fn(9), 43);
+
+        hook.reset();
+
+        EXPECT_EQ(fn(7), 0);
+        EXPECT_EQ(fn(8), 0);
+        EXPECT_EQ(fn(9), 1);
+
+        cg.reset();
+    }
+
+    SCOPED_TRACE("JNL");
+    {
+        cg.cmp(param, 8);
+        cg.jnl(label);
+        const auto fn = finalize();
+
+        EXPECT_EQ(fn(7), 0);
+        EXPECT_EQ(fn(8), 1);
+        EXPECT_EQ(fn(9), 1);
+
+        hook = safetyhook::create_inline(fn, Hook::fn);
+
+        EXPECT_EQ(fn(7), 42);
+        EXPECT_EQ(fn(8), 43);
+        EXPECT_EQ(fn(9), 43);
+
+        hook.reset();
+
+        EXPECT_EQ(fn(7), 0);
+        EXPECT_EQ(fn(8), 1);
+        EXPECT_EQ(fn(9), 1);
+
+        cg.reset();
+    }
+
+    SCOPED_TRACE("JNLE");
+    {
+        cg.cmp(param, 8);
+        cg.jnle(label);
+        const auto fn = finalize();
+
+        EXPECT_EQ(fn(7), 0);
+        EXPECT_EQ(fn(8), 0);
+        EXPECT_EQ(fn(9), 1);
+
+        hook = safetyhook::create_inline(fn, Hook::fn);
+
+        EXPECT_EQ(fn(7), 42);
+        EXPECT_EQ(fn(8), 42);
+        EXPECT_EQ(fn(9), 43);
+
+        hook.reset();
+
+        EXPECT_EQ(fn(7), 0);
+        EXPECT_EQ(fn(8), 0);
+        EXPECT_EQ(fn(9), 1);
+
+        cg.reset();
+    }
+
+    SCOPED_TRACE("JNO");
+    {
+        cg.cmp(param, 8);
+        cg.jno(label);
+        const auto fn = finalize();
+
+        EXPECT_EQ(fn(7), 1);
+        EXPECT_EQ(fn(8), 1);
+        EXPECT_EQ(fn(9), 1);
+
+        hook = safetyhook::create_inline(fn, Hook::fn);
+
+        EXPECT_EQ(fn(7), 43);
+        EXPECT_EQ(fn(8), 43);
+        EXPECT_EQ(fn(9), 43);
+
+        hook.reset();
+
+        EXPECT_EQ(fn(7), 1);
+        EXPECT_EQ(fn(8), 1);
+        EXPECT_EQ(fn(9), 1);
+
+        cg.reset();
+    }
+
+    SCOPED_TRACE("JNP");
+    {
+        cg.cmp(param, 8);
+        cg.jnp(label);
+        const auto fn = finalize();
+
+        EXPECT_EQ(fn(7), 0);
+        EXPECT_EQ(fn(8), 0);
+        EXPECT_EQ(fn(9), 1);
+
+        hook = safetyhook::create_inline(fn, Hook::fn);
+
+        EXPECT_EQ(fn(7), 42);
+        EXPECT_EQ(fn(8), 42);
+        EXPECT_EQ(fn(9), 43);
+
+        hook.reset();
+
+        EXPECT_EQ(fn(7), 0);
+        EXPECT_EQ(fn(8), 0);
+        EXPECT_EQ(fn(9), 1);
+
+        cg.reset();
+    }
+
+    SCOPED_TRACE("JNS");
+    {
+        cg.cmp(param, 8);
+        cg.jns(label);
+        const auto fn = finalize();
+
+        EXPECT_EQ(fn(7), 0);
+        EXPECT_EQ(fn(8), 1);
+        EXPECT_EQ(fn(9), 1);
+
+        hook = safetyhook::create_inline(fn, Hook::fn);
+
+        EXPECT_EQ(fn(7), 42);
+        EXPECT_EQ(fn(8), 43);
+        EXPECT_EQ(fn(9), 43);
+
+        hook.reset();
+
+        EXPECT_EQ(fn(7), 0);
+        EXPECT_EQ(fn(8), 1);
+        EXPECT_EQ(fn(9), 1);
+
+        cg.reset();
+    }
+
+    SCOPED_TRACE("JNZ");
+    {
+        cg.cmp(param, 8);
+        cg.jnz(label);
+        const auto fn = finalize();
+
+        EXPECT_EQ(fn(7), 1);
+        EXPECT_EQ(fn(8), 0);
+        EXPECT_EQ(fn(9), 1);
+
+        hook = safetyhook::create_inline(fn, Hook::fn);
+
+        EXPECT_EQ(fn(7), 43);
+        EXPECT_EQ(fn(8), 42);
+        EXPECT_EQ(fn(9), 43);
+
+        hook.reset();
+
+        EXPECT_EQ(fn(7), 1);
+        EXPECT_EQ(fn(8), 0);
+        EXPECT_EQ(fn(9), 1);
+
+        cg.reset();
+    }
+
+    SCOPED_TRACE("JO");
+    {
+        cg.cmp(param, 8);
+        cg.jo(label);
+        const auto fn = finalize();
+
+        EXPECT_EQ(fn(7), 0);
+        EXPECT_EQ(fn(8), 0);
+        EXPECT_EQ(fn(9), 0);
+
+        hook = safetyhook::create_inline(fn, Hook::fn);
+
+        EXPECT_EQ(fn(7), 42);
+        EXPECT_EQ(fn(8), 42);
+        EXPECT_EQ(fn(9), 42);
+
+        hook.reset();
+
+        EXPECT_EQ(fn(7), 0);
+        EXPECT_EQ(fn(8), 0);
+        EXPECT_EQ(fn(9), 0);
+
+        cg.reset();
+    }
+
+    SCOPED_TRACE("JP");
+    {
+        cg.cmp(param, 8);
+        cg.jp(label);
+        const auto fn = finalize();
+
+        EXPECT_EQ(fn(7), 1);
+        EXPECT_EQ(fn(8), 1);
+        EXPECT_EQ(fn(9), 0);
+
+        hook = safetyhook::create_inline(fn, Hook::fn);
+
+        EXPECT_EQ(fn(7), 43);
+        EXPECT_EQ(fn(8), 43);
+        EXPECT_EQ(fn(9), 42);
+
+        hook.reset();
+
+        EXPECT_EQ(fn(7), 1);
+        EXPECT_EQ(fn(8), 1);
+        EXPECT_EQ(fn(9), 0);
+
+        cg.reset();
+    }
+
+    SCOPED_TRACE("JS");
+    {
+        cg.cmp(param, 8);
+        cg.js(label);
+        const auto fn = finalize();
+
+        EXPECT_EQ(fn(7), 1);
+        EXPECT_EQ(fn(8), 0);
+        EXPECT_EQ(fn(9), 0);
+
+        hook = safetyhook::create_inline(fn, Hook::fn);
+
+        EXPECT_EQ(fn(7), 43);
+        EXPECT_EQ(fn(8), 42);
+        EXPECT_EQ(fn(9), 42);
+
+        hook.reset();
+
+        EXPECT_EQ(fn(7), 1);
+        EXPECT_EQ(fn(8), 0);
+        EXPECT_EQ(fn(9), 0);
+
+        cg.reset();
+    }
+
+    SCOPED_TRACE("JZ");
+    {
+        cg.cmp(param, 8);
+        cg.jz(label);
+        const auto fn = finalize();
+
+        EXPECT_EQ(fn(7), 0);
+        EXPECT_EQ(fn(8), 1);
+        EXPECT_EQ(fn(9), 0);
+
+        hook = safetyhook::create_inline(fn, Hook::fn);
+
+        EXPECT_EQ(fn(7), 42);
+        EXPECT_EQ(fn(8), 43);
+        EXPECT_EQ(fn(9), 42);
+
+        hook.reset();
+
+        EXPECT_EQ(fn(7), 0);
+        EXPECT_EQ(fn(8), 1);
+        EXPECT_EQ(fn(9), 0);
+
+        cg.reset();
+    }
+}
+
+TEST(InlineHook, FunctionWithShortJumpInsideTrampoline) {
+    Xbyak::CodeGenerator cg{};
+
+    cg.jmp("@f");
+    cg.ret();
+    cg.L("@@");
+    cg.mov(eax, 42);
+    cg.ret();
+    cg.nop(10, false);
+
+    const auto fn = cg.getCode<int (*)()>();
+
+    EXPECT_EQ(fn(), 42);
+
+    static SafetyHookInline hook;
+
+    struct Hook {
+        static int fn() { return hook.call<int>() + 1; }
     };
-};
+
+    hook = safetyhook::create_inline(fn, Hook::fn);
+
+    EXPECT_EQ(fn(), 43);
+
+    hook.reset();
+
+    EXPECT_EQ(fn(), 42);
+}
+
+TEST(InlineHook, FunctionHookCanBeEnableAndDisabled) {
+    struct Target {
+        SAFETYHOOK_NOINLINE static int fn(int a) {
+            volatile int b = a;
+            return b * 2;
+        }
+    };
+
+    EXPECT_EQ(Target::fn(1), 2);
+    EXPECT_EQ(Target::fn(2), 4);
+    EXPECT_EQ(Target::fn(3), 6);
+
+    static SafetyHookInline hook;
+
+    struct Hook {
+        static int fn(int a) { return hook.call<int>(a + 1); }
+    };
+
+    auto hook0_result = SafetyHookInline::create(Target::fn, Hook::fn, SafetyHookInline::StartDisabled);
+
+    ASSERT_TRUE(hook0_result.has_value());
+
+    hook = std::move(*hook0_result);
+
+    EXPECT_EQ(Target::fn(1), 2);
+    EXPECT_EQ(Target::fn(2), 4);
+    EXPECT_EQ(Target::fn(3), 6);
+
+    ASSERT_TRUE(hook.enable().has_value());
+
+    EXPECT_EQ(Target::fn(1), 4);
+    EXPECT_EQ(Target::fn(2), 6);
+    EXPECT_EQ(Target::fn(3), 8);
+
+    ASSERT_TRUE(hook.disable().has_value());
+
+    EXPECT_EQ(Target::fn(1), 2);
+    EXPECT_EQ(Target::fn(2), 4);
+    EXPECT_EQ(Target::fn(3), 6);
+
+    hook.reset();
+
+    EXPECT_EQ(Target::fn(1), 2);
+    EXPECT_EQ(Target::fn(2), 4);
+    EXPECT_EQ(Target::fn(3), 6);
 }

--- a/test/inline_hook.x86_64.cpp
+++ b/test/inline_hook.x86_64.cpp
@@ -1,11 +1,10 @@
-#include <boost/ut.hpp>
+#include <gtest/gtest.h>
 #include <safetyhook.hpp>
 #include <xbyak/xbyak.h>
 
 #if SAFETYHOOK_ARCH_X86_64
 
 using namespace std::literals;
-using namespace boost::ut;
 using namespace Xbyak::util;
 
 void asciiz(Xbyak::CodeGenerator& cg, const char* str) {
@@ -16,94 +15,88 @@ void asciiz(Xbyak::CodeGenerator& cg, const char* str) {
     cg.db(0);
 }
 
-void register_inline_hook_x64_tests() {
-suite<"inline hook (x64)"> inline_hook_x64_tests = [] {
-    "Function with RIP-relative operand is hooked"_test = [] {
-        Xbyak::CodeGenerator cg{};
-        Xbyak::Label str_label{};
+TEST(InlineHookX64, FunctionWithRIPRelativeOperandIsHooked) {
+    Xbyak::CodeGenerator cg{};
+    Xbyak::Label str_label{};
 
-        cg.lea(rax, ptr[rip + str_label]);
-        cg.ret();
+    cg.lea(rax, ptr[rip + str_label]);
+    cg.ret();
 
-        for (auto i = 0; i < 10; ++i) {
-            cg.nop(10, false);
-        }
+    for (auto i = 0; i < 10; ++i) {
+        cg.nop(10, false);
+    }
 
-        cg.L(str_label);
-        asciiz(cg, "Hello");
+    cg.L(str_label);
+    asciiz(cg, "Hello");
 
-        const auto fn = cg.getCode<const char* (*)()>();
+    const auto fn = cg.getCode<const char* (*)()>();
 
-        expect(eq(fn(), "Hello"sv));
+    EXPECT_EQ(fn(), "Hello"sv);
 
-        static SafetyHookInline hook;
+    static SafetyHookInline hook;
 
-        struct Hook {
-            static const char* fn() { return "Hello, world!"; }
-        };
-
-        auto hook_result = SafetyHookInline::create(fn, Hook::fn);
-
-        expect(hook_result.has_value());
-
-        hook = std::move(*hook_result);
-
-        expect(eq(fn(), "Hello, world!"sv));
-
-        hook.reset();
-
-        expect(eq(fn(), "Hello"sv));
+    struct Hook {
+        static const char* fn() { return "Hello, world!"; }
     };
 
-    "Function with no nearby memory is hooked"_test = [] {
-        Xbyak::CodeGenerator cg{5'000'000'000}; // 5 GB
-        Xbyak::Label start{};
+    auto hook_result = SafetyHookInline::create(fn, Hook::fn);
 
-        cg.nop(2'500'000'000, false); // 2.5 GB
-        cg.L(start);
+    ASSERT_TRUE(hook_result.has_value());
 
-#if SAFETYHOOK_OS_WINDOWS
-        cg.mov(dword[rsp + 8], ecx);
-        cg.mov(eax, dword[rsp + 8]);
-        cg.imul(eax, dword[rsp + 8]);
-#elif SAFETYHOOK_OS_LINUX
-        cg.mov(eax, edi);
-        cg.imul(eax, edi);
-#endif
+    hook = std::move(*hook_result);
 
-        cg.ret();
+    EXPECT_EQ(fn(), "Hello, world!"sv);
 
-        auto fn = reinterpret_cast<int (*)(int)>(const_cast<uint8_t*>(start.getAddress()));
+    hook.reset();
 
-        expect(fn(2) == 4_i);
-        expect(fn(3) == 9_i);
-        expect(fn(4) == 16_i);
-
-        static SafetyHookInline hook;
-
-        struct Hook {
-            static int fn(int a) { return hook.call<int>(a) * a; }
-        };
-
-        auto hook_result = SafetyHookInline::create(fn, Hook::fn);
-
-        expect(hook_result.has_value());
-
-        hook = std::move(*hook_result);
-
-        expect(fn(2) == 8_i);
-        expect(fn(3) == 27_i);
-        expect(fn(4) == 64_i);
-
-        hook.reset();
-
-        expect(fn(2) == 4_i);
-        expect(fn(3) == 9_i);
-        expect(fn(4) == 16_i);
-    };
-};
+    EXPECT_EQ(fn(), "Hello"sv);
 }
 
-#else
-void register_inline_hook_x64_tests() {}
+TEST(InlineHookX64, FunctionWithNoNearbyMemoryIsHooked) {
+    Xbyak::CodeGenerator cg{5'000'000'000}; // 5 GB
+    Xbyak::Label start{};
+
+    cg.nop(2'500'000'000, false); // 2.5 GB
+    cg.L(start);
+
+#if SAFETYHOOK_OS_WINDOWS
+    cg.mov(dword[rsp + 8], ecx);
+    cg.mov(eax, dword[rsp + 8]);
+    cg.imul(eax, dword[rsp + 8]);
+#elif SAFETYHOOK_OS_LINUX
+    cg.mov(eax, edi);
+    cg.imul(eax, edi);
+#endif
+
+    cg.ret();
+
+    auto fn = reinterpret_cast<int (*)(int)>(const_cast<uint8_t*>(start.getAddress()));
+
+    EXPECT_EQ(fn(2), 4);
+    EXPECT_EQ(fn(3), 9);
+    EXPECT_EQ(fn(4), 16);
+
+    static SafetyHookInline hook;
+
+    struct Hook {
+        static int fn(int a) { return hook.call<int>(a) * a; }
+    };
+
+    auto hook_result = SafetyHookInline::create(fn, Hook::fn);
+
+    ASSERT_TRUE(hook_result.has_value());
+
+    hook = std::move(*hook_result);
+
+    EXPECT_EQ(fn(2), 8);
+    EXPECT_EQ(fn(3), 27);
+    EXPECT_EQ(fn(4), 64);
+
+    hook.reset();
+
+    EXPECT_EQ(fn(2), 4);
+    EXPECT_EQ(fn(3), 9);
+    EXPECT_EQ(fn(4), 16);
+}
+
 #endif

--- a/test/inline_hook.x86_64.cpp
+++ b/test/inline_hook.x86_64.cpp
@@ -1,3 +1,6 @@
+#include <cstdint>
+#include <string_view>
+
 #include <gtest/gtest.h>
 #include <safetyhook.hpp>
 #include <xbyak/xbyak.h>

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -1,17 +1,6 @@
-#include <boost/ut.hpp>
+#include <gtest/gtest.h>
 
-void register_allocator_tests();
-void register_inline_hook_tests();
-void register_inline_hook_x64_tests();
-void register_mid_hook_tests();
-void register_vmt_hook_tests();
-
-int main() {
-    register_allocator_tests();
-    register_inline_hook_tests();
-    register_inline_hook_x64_tests();
-    register_mid_hook_tests();
-    register_vmt_hook_tests();
-
-    return boost::ut::cfg<>.run({.report_errors = true}) ? 1 : 0;
+int main(int argc, char** argv) {
+    testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
 }

--- a/test/mid_hook.cpp
+++ b/test/mid_hook.cpp
@@ -1,137 +1,131 @@
-#include <boost/ut.hpp>
+#include <gtest/gtest.h>
 #include <safetyhook.hpp>
 
-using namespace boost::ut;
+TEST(MidHook, MidHookToChangeARegister) {
+    struct Target {
+        SAFETYHOOK_NOINLINE static int SAFETYHOOK_FASTCALL add_42(int a) { return a + 42; }
+    };
 
-void register_mid_hook_tests() {
-suite<"mid hook"> mid_hook_tests = [] {
-    "Mid hook to change a register"_test = [] {
-        struct Target {
-            SAFETYHOOK_NOINLINE static int SAFETYHOOK_FASTCALL add_42(int a) { return a + 42; }
-        };
+    EXPECT_EQ(Target::add_42(0), 42);
 
-        expect(Target::add_42(0) == 42_i);
+    static SafetyHookMid hook;
 
-        static SafetyHookMid hook;
-
-        struct Hook {
-            static void add_42(SafetyHookContext& ctx) {
+    struct Hook {
+        static void add_42(SafetyHookContext& ctx) {
 #if SAFETYHOOK_OS_WINDOWS
 #if SAFETYHOOK_ARCH_X86_64
-                ctx.rcx = 1337 - 42;
+            ctx.rcx = 1337 - 42;
 #elif SAFETYHOOK_ARCH_X86_32
-                ctx.ecx = 1337 - 42;
+            ctx.ecx = 1337 - 42;
 #endif
 #elif SAFETYHOOK_OS_LINUX
 #if SAFETYHOOK_ARCH_X86_64
-                ctx.rdi = 1337 - 42;
+            ctx.rdi = 1337 - 42;
 #elif SAFETYHOOK_ARCH_X86_32
-                ctx.edi = 1337 - 42;
+            ctx.edi = 1337 - 42;
 #endif
 #endif
-            }
-        };
-
-        auto hook_result = SafetyHookMid::create(Target::add_42, Hook::add_42);
-
-        expect(hook_result.has_value());
-
-        hook = std::move(*hook_result);
-
-        expect(Target::add_42(1) == 1337_i);
-
-        hook.reset();
-
-        expect(Target::add_42(2) == 44_i);
+        }
     };
+
+    auto hook_result = SafetyHookMid::create(Target::add_42, Hook::add_42);
+
+    ASSERT_TRUE(hook_result.has_value());
+
+    hook = std::move(*hook_result);
+
+    EXPECT_EQ(Target::add_42(1), 1337);
+
+    hook.reset();
+
+    EXPECT_EQ(Target::add_42(2), 44);
+}
 
 #if SAFETYHOOK_ARCH_X86_64
-    "Mid hook to change an XMM register"_test = [] {
-        struct Target {
-            SAFETYHOOK_NOINLINE static float SAFETYHOOK_FASTCALL add_42(float a) { return a + 0.42f; }
-        };
-
-        expect(Target::add_42(0.0f) == 0.42_f);
-
-        static SafetyHookMid hook;
-
-        struct Hook {
-            static void add_42(SafetyHookContext& ctx) { ctx.xmm0.f32[0] = 1337.0f - 0.42f; }
-        };
-
-        auto hook_result = SafetyHookMid::create(Target::add_42, Hook::add_42);
-
-        expect(hook_result.has_value());
-
-        hook = std::move(*hook_result);
-
-        expect(Target::add_42(1.0f) == 1337.0_f);
-
-        hook.reset();
-
-        expect(Target::add_42(2.0f) == 2.42_f);
+TEST(MidHook, MidHookToChangeAnXMMRegister) {
+    struct Target {
+        SAFETYHOOK_NOINLINE static float SAFETYHOOK_FASTCALL add_42(float a) { return a + 0.42f; }
     };
+
+    EXPECT_FLOAT_EQ(Target::add_42(0.0f), 0.42);
+
+    static SafetyHookMid hook;
+
+    struct Hook {
+        static void add_42(SafetyHookContext& ctx) { ctx.xmm0.f32[0] = 1337.0f - 0.42f; }
+    };
+
+    auto hook_result = SafetyHookMid::create(Target::add_42, Hook::add_42);
+
+    ASSERT_TRUE(hook_result.has_value());
+
+    hook = std::move(*hook_result);
+
+    EXPECT_FLOAT_EQ(Target::add_42(1.0f), 1337.0);
+
+    hook.reset();
+
+    EXPECT_FLOAT_EQ(Target::add_42(2.0f), 2.42);
+}
 #endif
 
-    "Mid hook enable and disable"_test = [] {
-        struct Target {
-            SAFETYHOOK_NOINLINE static int SAFETYHOOK_FASTCALL add_42(int a) {
-                volatile int b = a;
-                return b + 42;
-            }
-        };
+TEST(MidHook, MidHookEnableAndDisable) {
+    struct Target {
+        SAFETYHOOK_NOINLINE static int SAFETYHOOK_FASTCALL add_42(int a) {
+            volatile int b = a;
+            return b + 42;
+        }
+    };
 
-        expect(Target::add_42(0) == 42_i);
-        expect(Target::add_42(1) == 43_i);
-        expect(Target::add_42(2) == 44_i);
+    EXPECT_EQ(Target::add_42(0), 42);
+    EXPECT_EQ(Target::add_42(1), 43);
+    EXPECT_EQ(Target::add_42(2), 44);
 
-        static SafetyHookMid hook;
+    static SafetyHookMid hook;
 
-        struct Hook {
-            static void add_42(SafetyHookContext& ctx) {
+    struct Hook {
+        static void add_42(SafetyHookContext& ctx) {
 #if SAFETYHOOK_OS_WINDOWS
 #if SAFETYHOOK_ARCH_X86_64
-                ctx.rcx = 1337 - 42;
+            ctx.rcx = 1337 - 42;
 #elif SAFETYHOOK_ARCH_X86_32
-                ctx.ecx = 1337 - 42;
+            ctx.ecx = 1337 - 42;
 #endif
 #elif SAFETYHOOK_OS_LINUX
 #if SAFETYHOOK_ARCH_X86_64
-                ctx.rdi = 1337 - 42;
+            ctx.rdi = 1337 - 42;
 #elif SAFETYHOOK_ARCH_X86_32
-                ctx.edi = 1337 - 42;
+            ctx.edi = 1337 - 42;
 #endif
 #endif
-            }
-        };
-
-        auto hook_result = SafetyHookMid::create(Target::add_42, Hook::add_42, SafetyHookMid::StartDisabled);
-
-        expect(hook_result.has_value());
-
-        hook = std::move(*hook_result);
-
-        expect(Target::add_42(0) == 42_i);
-        expect(Target::add_42(1) == 43_i);
-        expect(Target::add_42(2) == 44_i);
-
-        expect(hook.enable().has_value());
-
-        expect(Target::add_42(1) == 1337_i);
-        expect(Target::add_42(2) == 1337_i);
-        expect(Target::add_42(3) == 1337_i);
-
-        expect(hook.disable().has_value());
-
-        expect(Target::add_42(0) == 42_i);
-        expect(Target::add_42(1) == 43_i);
-        expect(Target::add_42(2) == 44_i);
-
-        hook.reset();
-
-        expect(Target::add_42(0) == 42_i);
-        expect(Target::add_42(1) == 43_i);
-        expect(Target::add_42(2) == 44_i);
+        }
     };
-};
+
+    auto hook_result = SafetyHookMid::create(Target::add_42, Hook::add_42, SafetyHookMid::StartDisabled);
+
+    ASSERT_TRUE(hook_result.has_value());
+
+    hook = std::move(*hook_result);
+
+    EXPECT_EQ(Target::add_42(0), 42);
+    EXPECT_EQ(Target::add_42(1), 43);
+    EXPECT_EQ(Target::add_42(2), 44);
+
+    ASSERT_TRUE(hook.enable().has_value());
+
+    EXPECT_EQ(Target::add_42(1), 1337);
+    EXPECT_EQ(Target::add_42(2), 1337);
+    EXPECT_EQ(Target::add_42(3), 1337);
+
+    ASSERT_TRUE(hook.disable().has_value());
+
+    EXPECT_EQ(Target::add_42(0), 42);
+    EXPECT_EQ(Target::add_42(1), 43);
+    EXPECT_EQ(Target::add_42(2), 44);
+
+    hook.reset();
+
+    EXPECT_EQ(Target::add_42(0), 42);
+    EXPECT_EQ(Target::add_42(1), 43);
+    EXPECT_EQ(Target::add_42(2), 44);
 }

--- a/test/mid_hook.cpp
+++ b/test/mid_hook.cpp
@@ -47,7 +47,7 @@ TEST(MidHook, MidHookToChangeAnXMMRegister) {
         SAFETYHOOK_NOINLINE static float SAFETYHOOK_FASTCALL add_42(float a) { return a + 0.42f; }
     };
 
-    EXPECT_FLOAT_EQ(Target::add_42(0.0f), 0.42);
+    EXPECT_FLOAT_EQ(Target::add_42(0.0f), 0.42f);
 
     static SafetyHookMid hook;
 
@@ -61,11 +61,11 @@ TEST(MidHook, MidHookToChangeAnXMMRegister) {
 
     hook = std::move(*hook_result);
 
-    EXPECT_FLOAT_EQ(Target::add_42(1.0f), 1337.0);
+    EXPECT_FLOAT_EQ(Target::add_42(1.0f), 1337.0f);
 
     hook.reset();
 
-    EXPECT_FLOAT_EQ(Target::add_42(2.0f), 2.42);
+    EXPECT_FLOAT_EQ(Target::add_42(2.0f), 2.42f);
 }
 #endif
 

--- a/test/vmt_hook.cpp
+++ b/test/vmt_hook.cpp
@@ -1,9 +1,8 @@
-#include <boost/ut.hpp>
+#include <gtest/gtest.h>
 #include <safetyhook.hpp>
 
 #include "vmt_targets.hpp"
 
-using namespace boost::ut;
 using namespace safetyhook::test;
 
 #if SAFETYHOOK_ABI_MSVC
@@ -12,319 +11,315 @@ static constexpr auto VMT_OFFSET = 0;
 static constexpr auto VMT_OFFSET = 1;
 #endif
 
-void register_vmt_hook_tests() {
-suite<"vmt hook"> vmt_hook_tests = [] {
-    "VMT hook an object instance"_test = [] {
-        auto target = make_single_target();
+TEST(VmtHook, VMTHookAnObjectInstance) {
+    auto target = make_single_target();
 
-        expect(target->add_42(0) == 42_i);
+    EXPECT_EQ(target->add_42(0), 42);
 
-        static SafetyHookVmt target_hook{};
-        static SafetyHookVm add_42_hook{};
+    static SafetyHookVmt target_hook{};
+    static SafetyHookVm add_42_hook{};
 
-        struct Hook : SingleTarget {
-            int hooked_add_42(int a) { return add_42_hook.thiscall<int>(this, a) + 1337; }
-        };
-
-        auto vmt_result = SafetyHookVmt::create(target.get());
-
-        expect(vmt_result.has_value());
-
-        target_hook = std::move(*vmt_result);
-
-        auto vm_result = target_hook.hook_method(1 + VMT_OFFSET, &Hook::hooked_add_42);
-
-        expect(vm_result.has_value());
-
-        add_42_hook = std::move(*vm_result);
-
-        expect(target->add_42(1) == 1380_i);
-
-        add_42_hook.reset();
-
-        expect(target->add_42(2) == 44_i);
-
-        target_hook.reset();
+    struct Hook : SingleTarget {
+        int hooked_add_42(int a) { return add_42_hook.thiscall<int>(this, a) + 1337; }
     };
 
-    "Resetting the VMT hook removes all VM hooks for that object"_test = [] {
-        auto target = make_dual_target();
+    auto vmt_result = SafetyHookVmt::create(target.get());
 
-        expect(target->add_42(0) == 42_i);
-        expect(target->add_43(0) == 43_i);
+    ASSERT_TRUE(vmt_result.has_value());
 
-        static SafetyHookVmt target_hook{};
-        static SafetyHookVm add_42_hook{};
-        static SafetyHookVm add_43_hook{};
+    target_hook = std::move(*vmt_result);
 
-        struct Hook : DualTarget {
-            int hooked_add_42(int a) { return add_42_hook.thiscall<int>(this, a) + 1337; }
-            int hooked_add_43(int a) { return add_43_hook.thiscall<int>(this, a) + 1337; }
-        };
+    auto vm_result = target_hook.hook_method(1 + VMT_OFFSET, &Hook::hooked_add_42);
 
-        auto vmt_result = SafetyHookVmt::create(target.get());
+    ASSERT_TRUE(vm_result.has_value());
 
-        expect(vmt_result.has_value());
+    add_42_hook = std::move(*vm_result);
 
-        target_hook = std::move(*vmt_result);
+    EXPECT_EQ(target->add_42(1), 1380);
 
-        auto vm_result = target_hook.hook_method(1 + VMT_OFFSET, &Hook::hooked_add_42);
+    add_42_hook.reset();
 
-        expect(vm_result.has_value());
+    EXPECT_EQ(target->add_42(2), 44);
 
-        add_42_hook = std::move(*vm_result);
+    target_hook.reset();
+}
 
-        expect(target->add_42(1) == 1380_i);
+TEST(VmtHook, ResettingTheVMTHookRemovesAllVMHooksForThatObject) {
+    auto target = make_dual_target();
 
-        vm_result = target_hook.hook_method(2 + VMT_OFFSET, &Hook::hooked_add_43);
+    EXPECT_EQ(target->add_42(0), 42);
+    EXPECT_EQ(target->add_43(0), 43);
 
-        expect(vm_result.has_value());
+    static SafetyHookVmt target_hook{};
+    static SafetyHookVm add_42_hook{};
+    static SafetyHookVm add_43_hook{};
 
-        add_43_hook = std::move(*vm_result);
-
-        expect(target->add_43(1) == 1381_i);
-
-        target_hook.reset();
-
-        expect(target->add_42(2) == 44_i);
-        expect(target->add_43(2) == 45_i);
-
-        add_42_hook.reset();
-        add_43_hook.reset();
+    struct Hook : DualTarget {
+        int hooked_add_42(int a) { return add_42_hook.thiscall<int>(this, a) + 1337; }
+        int hooked_add_43(int a) { return add_43_hook.thiscall<int>(this, a) + 1337; }
     };
 
-    "VMT hooking an object maintains correct RTTI"_test = [] {
-        auto target = make_single_target();
+    auto vmt_result = SafetyHookVmt::create(target.get());
 
-        expect(target->add_42(0) == 42_i);
-        expect(neq(dynamic_cast<SingleInterface*>(target.get()), nullptr));
+    ASSERT_TRUE(vmt_result.has_value());
 
-        static SafetyHookVmt target_hook{};
-        static SafetyHookVm add_42_hook{};
+    target_hook = std::move(*vmt_result);
 
-        struct Hook : SingleTarget {
-            int hooked_add_42(int a) { return add_42_hook.thiscall<int>(this, a) + 1337; }
-        };
+    auto vm_result = target_hook.hook_method(1 + VMT_OFFSET, &Hook::hooked_add_42);
 
-        auto vmt_result = SafetyHookVmt::create(target.get());
+    ASSERT_TRUE(vm_result.has_value());
 
-        expect(vmt_result.has_value());
+    add_42_hook = std::move(*vm_result);
 
-        target_hook = std::move(*vmt_result);
+    EXPECT_EQ(target->add_42(1), 1380);
 
-        auto vm_result = target_hook.hook_method(1 + VMT_OFFSET, &Hook::hooked_add_42);
+    vm_result = target_hook.hook_method(2 + VMT_OFFSET, &Hook::hooked_add_43);
 
-        expect(vm_result.has_value());
+    ASSERT_TRUE(vm_result.has_value());
 
-        add_42_hook = std::move(*vm_result);
+    add_43_hook = std::move(*vm_result);
 
-        expect(target->add_42(1) == 1380_i);
-        expect(neq(dynamic_cast<SingleInterface*>(target.get()), nullptr));
+    EXPECT_EQ(target->add_43(1), 1381);
 
-        add_42_hook.reset();
-        target_hook.reset();
+    target_hook.reset();
+
+    EXPECT_EQ(target->add_42(2), 44);
+    EXPECT_EQ(target->add_43(2), 45);
+
+    add_42_hook.reset();
+    add_43_hook.reset();
+}
+
+TEST(VmtHook, VMTHookingAnObjectMaintainsCorrectRTTI) {
+    auto target = make_single_target();
+
+    EXPECT_EQ(target->add_42(0), 42);
+    EXPECT_NE(dynamic_cast<SingleInterface*>(target.get()), nullptr);
+
+    static SafetyHookVmt target_hook{};
+    static SafetyHookVm add_42_hook{};
+
+    struct Hook : SingleTarget {
+        int hooked_add_42(int a) { return add_42_hook.thiscall<int>(this, a) + 1337; }
     };
 
-    "Can safely destroy VmtHook after object is deleted"_test = [] {
-        auto target = make_single_target();
+    auto vmt_result = SafetyHookVmt::create(target.get());
 
-        expect(target->add_42(0) == 42_i);
+    ASSERT_TRUE(vmt_result.has_value());
 
-        static SafetyHookVmt target_hook{};
-        static SafetyHookVm add_42_hook{};
+    target_hook = std::move(*vmt_result);
 
-        struct Hook : SingleTarget {
-            int hooked_add_42(int a) { return add_42_hook.thiscall<int>(this, a) + 1337; }
-        };
+    auto vm_result = target_hook.hook_method(1 + VMT_OFFSET, &Hook::hooked_add_42);
 
-        auto vmt_result = SafetyHookVmt::create(target.get());
+    ASSERT_TRUE(vm_result.has_value());
 
-        expect(vmt_result.has_value());
+    add_42_hook = std::move(*vm_result);
 
-        target_hook = std::move(*vmt_result);
+    EXPECT_EQ(target->add_42(1), 1380);
+    EXPECT_NE(dynamic_cast<SingleInterface*>(target.get()), nullptr);
 
-        auto vm_result = target_hook.hook_method(1 + VMT_OFFSET, &Hook::hooked_add_42);
+    add_42_hook.reset();
+    target_hook.reset();
+}
 
-        expect(vm_result.has_value());
+TEST(VmtHook, CanSafelyDestroyVmtHookAfterObjectIsDeleted) {
+    auto target = make_single_target();
 
-        add_42_hook = std::move(*vm_result);
+    EXPECT_EQ(target->add_42(0), 42);
 
-        expect(target->add_42(1) == 1380_i);
+    static SafetyHookVmt target_hook{};
+    static SafetyHookVm add_42_hook{};
 
-        target.reset();
-        target_hook.reset();
-        add_42_hook.reset();
+    struct Hook : SingleTarget {
+        int hooked_add_42(int a) { return add_42_hook.thiscall<int>(this, a) + 1337; }
     };
 
-    "Can apply an existing VMT hook to more than one object"_test = [] {
-        auto target = make_single_target();
-        auto target0 = make_single_target();
-        auto target1 = make_single_target();
-        auto target2 = make_single_target();
+    auto vmt_result = SafetyHookVmt::create(target.get());
 
-        expect(target->add_42(0) == 42_i);
+    ASSERT_TRUE(vmt_result.has_value());
 
-        static SafetyHookVmt target_hook{};
-        static SafetyHookVm add_42_hook{};
+    target_hook = std::move(*vmt_result);
 
-        struct Hook : SingleTarget {
-            int hooked_add_42(int a) { return add_42_hook.thiscall<int>(this, a) + 1337; }
-        };
+    auto vm_result = target_hook.hook_method(1 + VMT_OFFSET, &Hook::hooked_add_42);
 
-        auto vmt_result = SafetyHookVmt::create(target.get());
+    ASSERT_TRUE(vm_result.has_value());
 
-        expect(vmt_result.has_value());
+    add_42_hook = std::move(*vm_result);
 
-        target_hook = std::move(*vmt_result);
+    EXPECT_EQ(target->add_42(1), 1380);
 
-        auto vm_result = target_hook.hook_method(1 + VMT_OFFSET, &Hook::hooked_add_42);
+    target.reset();
+    target_hook.reset();
+    add_42_hook.reset();
+}
 
-        expect(vm_result.has_value());
+TEST(VmtHook, CanApplyAnExistingVMTHookToMoreThanOneObject) {
+    auto target = make_single_target();
+    auto target0 = make_single_target();
+    auto target1 = make_single_target();
+    auto target2 = make_single_target();
 
-        add_42_hook = std::move(*vm_result);
+    EXPECT_EQ(target->add_42(0), 42);
 
-        target_hook.apply(target0.get());
-        target_hook.apply(target1.get());
-        target_hook.apply(target2.get());
+    static SafetyHookVmt target_hook{};
+    static SafetyHookVm add_42_hook{};
 
-        expect(target->add_42(1) == 1380_i);
-        expect(target0->add_42(1) == 1380_i);
-        expect(target1->add_42(1) == 1380_i);
-        expect(target2->add_42(1) == 1380_i);
-
-        add_42_hook.reset();
-
-        expect(target->add_42(2) == 44_i);
-        expect(target0->add_42(2) == 44_i);
-        expect(target1->add_42(2) == 44_i);
-        expect(target2->add_42(2) == 44_i);
-
-        target_hook.reset();
+    struct Hook : SingleTarget {
+        int hooked_add_42(int a) { return add_42_hook.thiscall<int>(this, a) + 1337; }
     };
 
-    "Can remove an object that was previously VMT hooked"_test = [] {
-        auto target = make_single_target();
-        auto target0 = make_single_target();
-        auto target1 = make_single_target();
-        auto target2 = make_single_target();
+    auto vmt_result = SafetyHookVmt::create(target.get());
 
-        expect(target->add_42(0) == 42_i);
+    ASSERT_TRUE(vmt_result.has_value());
 
-        static SafetyHookVmt target_hook{};
-        static SafetyHookVm add_42_hook{};
+    target_hook = std::move(*vmt_result);
 
-        struct Hook : SingleTarget {
-            int hooked_add_42(int a) { return add_42_hook.thiscall<int>(this, a) + 1337; }
-        };
+    auto vm_result = target_hook.hook_method(1 + VMT_OFFSET, &Hook::hooked_add_42);
 
-        auto vmt_result = SafetyHookVmt::create(target.get());
+    ASSERT_TRUE(vm_result.has_value());
 
-        expect(vmt_result.has_value());
+    add_42_hook = std::move(*vm_result);
 
-        target_hook = std::move(*vmt_result);
+    target_hook.apply(target0.get());
+    target_hook.apply(target1.get());
+    target_hook.apply(target2.get());
 
-        auto vm_result = target_hook.hook_method(1 + VMT_OFFSET, &Hook::hooked_add_42);
+    EXPECT_EQ(target->add_42(1), 1380);
+    EXPECT_EQ(target0->add_42(1), 1380);
+    EXPECT_EQ(target1->add_42(1), 1380);
+    EXPECT_EQ(target2->add_42(1), 1380);
 
-        expect(vm_result.has_value());
+    add_42_hook.reset();
 
-        add_42_hook = std::move(*vm_result);
+    EXPECT_EQ(target->add_42(2), 44);
+    EXPECT_EQ(target0->add_42(2), 44);
+    EXPECT_EQ(target1->add_42(2), 44);
+    EXPECT_EQ(target2->add_42(2), 44);
 
-        target_hook.apply(target0.get());
-        target_hook.apply(target1.get());
-        target_hook.apply(target2.get());
+    target_hook.reset();
+}
 
-        expect(target->add_42(1) == 1380_i);
-        expect(target0->add_42(1) == 1380_i);
-        expect(target1->add_42(1) == 1380_i);
-        expect(target2->add_42(1) == 1380_i);
+TEST(VmtHook, CanRemoveAnObjectThatWasPreviouslyVMTHooked) {
+    auto target = make_single_target();
+    auto target0 = make_single_target();
+    auto target1 = make_single_target();
+    auto target2 = make_single_target();
 
-        target_hook.remove(target0.get());
+    EXPECT_EQ(target->add_42(0), 42);
 
-        expect(target->add_42(2) == 1381_i);
-        expect(target0->add_42(2) == 44_i);
-        expect(target1->add_42(2) == 1381_i);
-        expect(target2->add_42(2) == 1381_i);
+    static SafetyHookVmt target_hook{};
+    static SafetyHookVm add_42_hook{};
 
-        target_hook.remove(target2.get());
-
-        expect(target->add_42(2) == 1381_i);
-        expect(target0->add_42(2) == 44_i);
-        expect(target1->add_42(2) == 1381_i);
-        expect(target2->add_42(2) == 44_i);
-
-        target_hook.remove(target.get());
-
-        expect(target->add_42(2) == 44_i);
-        expect(target0->add_42(2) == 44_i);
-        expect(target1->add_42(2) == 1381_i);
-        expect(target2->add_42(2) == 44_i);
-
-        target_hook.remove(target1.get());
-
-        expect(target->add_42(2) == 44_i);
-        expect(target0->add_42(2) == 44_i);
-        expect(target1->add_42(2) == 44_i);
-        expect(target2->add_42(2) == 44_i);
-
-        add_42_hook.reset();
-        target_hook.reset();
+    struct Hook : SingleTarget {
+        int hooked_add_42(int a) { return add_42_hook.thiscall<int>(this, a) + 1337; }
     };
 
-    "VMT hook an object instance with easy API"_test = [] {
-        auto target = make_single_target();
+    auto vmt_result = SafetyHookVmt::create(target.get());
 
-        expect(target->add_42(0) == 42_i);
+    ASSERT_TRUE(vmt_result.has_value());
 
-        static SafetyHookVmt target_hook{};
-        static SafetyHookVm add_42_hook{};
+    target_hook = std::move(*vmt_result);
 
-        struct Hook : SingleTarget {
-            int hooked_add_42(int a) { return add_42_hook.thiscall<int>(this, a) + 1337; }
-        };
+    auto vm_result = target_hook.hook_method(1 + VMT_OFFSET, &Hook::hooked_add_42);
 
-        target_hook = safetyhook::create_vmt(target.get());
-        add_42_hook = safetyhook::create_vm(target_hook, 1 + VMT_OFFSET, &Hook::hooked_add_42);
+    ASSERT_TRUE(vm_result.has_value());
 
-        expect(target->add_42(1) == 1380_i);
+    add_42_hook = std::move(*vm_result);
 
-        add_42_hook.reset();
+    target_hook.apply(target0.get());
+    target_hook.apply(target1.get());
+    target_hook.apply(target2.get());
 
-        expect(target->add_42(2) == 44_i);
+    EXPECT_EQ(target->add_42(1), 1380);
+    EXPECT_EQ(target0->add_42(1), 1380);
+    EXPECT_EQ(target1->add_42(1), 1380);
+    EXPECT_EQ(target2->add_42(1), 1380);
 
-        target_hook.reset();
+    target_hook.remove(target0.get());
+
+    EXPECT_EQ(target->add_42(2), 1381);
+    EXPECT_EQ(target0->add_42(2), 44);
+    EXPECT_EQ(target1->add_42(2), 1381);
+    EXPECT_EQ(target2->add_42(2), 1381);
+
+    target_hook.remove(target2.get());
+
+    EXPECT_EQ(target->add_42(2), 1381);
+    EXPECT_EQ(target0->add_42(2), 44);
+    EXPECT_EQ(target1->add_42(2), 1381);
+    EXPECT_EQ(target2->add_42(2), 44);
+
+    target_hook.remove(target.get());
+
+    EXPECT_EQ(target->add_42(2), 44);
+    EXPECT_EQ(target0->add_42(2), 44);
+    EXPECT_EQ(target1->add_42(2), 1381);
+    EXPECT_EQ(target2->add_42(2), 44);
+
+    target_hook.remove(target1.get());
+
+    EXPECT_EQ(target->add_42(2), 44);
+    EXPECT_EQ(target0->add_42(2), 44);
+    EXPECT_EQ(target1->add_42(2), 44);
+    EXPECT_EQ(target2->add_42(2), 44);
+
+    add_42_hook.reset();
+    target_hook.reset();
+}
+
+TEST(VmtHook, VMTHookAnObjectInstanceWithEasyAPI) {
+    auto target = make_single_target();
+
+    EXPECT_EQ(target->add_42(0), 42);
+
+    static SafetyHookVmt target_hook{};
+    static SafetyHookVm add_42_hook{};
+
+    struct Hook : SingleTarget {
+        int hooked_add_42(int a) { return add_42_hook.thiscall<int>(this, a) + 1337; }
     };
 
-    "VMT hook preserves dynamic_cast with cross-cast"_test = [] {
-        auto target = make_cast_target();
+    target_hook = safetyhook::create_vmt(target.get());
+    add_42_hook = safetyhook::create_vm(target_hook, 1 + VMT_OFFSET, &Hook::hooked_add_42);
 
-        CastBase2* base2 = target.get();
+    EXPECT_EQ(target->add_42(1), 1380);
 
-        static SafetyHookVmt base2_hook{};
-        static SafetyHookVm add_1337_hook{};
+    add_42_hook.reset();
 
-        struct Hook : CastTarget {
-            int hooked_add_1337(int a) { return add_1337_hook.thiscall<int>(this, a) + 42; }
-        };
+    EXPECT_EQ(target->add_42(2), 44);
 
-        auto vmt_result = SafetyHookVmt::create(base2);
-        expect(vmt_result.has_value());
-        base2_hook = std::move(*vmt_result);
+    target_hook.reset();
+}
 
-        auto vm_result = base2_hook.hook_method(1 + VMT_OFFSET, &Hook::hooked_add_1337);
-        expect(vm_result.has_value());
-        add_1337_hook = std::move(*vm_result);
+TEST(VmtHook, VMTHookPreservesDynamicCastWithCrossCast) {
+    auto target = make_cast_target();
 
-        expect(base2->add_1337(1) == 1380_i);
+    CastBase2* base2 = target.get();
 
-        // Cross-cast: CastBase2* -> CastBase1*
-        // Runtime reads offset-to-top from CastBase2's vptr[-2]
-        // Without the fix this is garbage and will crash or return wrong pointer
-        CastBase1* base1 = dynamic_cast<CastBase1*>(base2);
-        expect(neq(base1, nullptr));
-        expect(base1->add_42(1) == 43_i);
+    static SafetyHookVmt base2_hook{};
+    static SafetyHookVm add_1337_hook{};
 
-        add_1337_hook.reset();
-        base2_hook.reset();
+    struct Hook : CastTarget {
+        int hooked_add_1337(int a) { return add_1337_hook.thiscall<int>(this, a) + 42; }
     };
-};
+
+    auto vmt_result = SafetyHookVmt::create(base2);
+    ASSERT_TRUE(vmt_result.has_value());
+    base2_hook = std::move(*vmt_result);
+
+    auto vm_result = base2_hook.hook_method(1 + VMT_OFFSET, &Hook::hooked_add_1337);
+    ASSERT_TRUE(vm_result.has_value());
+    add_1337_hook = std::move(*vm_result);
+
+    EXPECT_EQ(base2->add_1337(1), 1380);
+
+    // Cross-cast: CastBase2* -> CastBase1*
+    // Runtime reads offset-to-top from CastBase2's vptr[-2]
+    // Without the fix this is garbage and will crash or return wrong pointer
+    CastBase1* base1 = dynamic_cast<CastBase1*>(base2);
+    EXPECT_NE(base1, nullptr);
+    EXPECT_EQ(base1->add_42(1), 43);
+
+    add_1337_hook.reset();
+    base2_hook.reset();
 }


### PR DESCRIPTION
## Summary

- Replace the Boost.UT test dependency with GoogleTest in `cmake.toml` and the generated `CMakeLists.txt`.
- Convert the test suite under `test/` to native GoogleTest `TEST` cases and assertions.
- Keep both `test` and `test-amalgamated` targets building and running.

## Validation

- `clang-format` via `C:\Program Files\LLVM\bin` on the changed test source.
- MSVC x64 Release: configured, built, and ran `test.exe` and `test-amalgamated.exe` successfully.
- clang-cl x64 Release: configured, built, and ran `test.exe` and `test-amalgamated.exe` successfully.
- MinGW x64 Release using `D:\w64devkit` GCC 16.1.0: configured, built, and ran `test.exe` and `test-amalgamated.exe` successfully.