### PR TITLE
Add clang-format enforcement

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -14,9 +14,9 @@ if [ "$clang_format_version" != "22" ]; then
     echo "found: $(clang-format --version)" >&2
 fi
 
-files=$(mktemp)
-staged_file=$(mktemp)
-formatted_file=$(mktemp)
+files=$(mktemp "${TMPDIR:-/tmp}/safetyhook-pre-commit.files.XXXXXX")
+staged_file=$(mktemp "${TMPDIR:-/tmp}/safetyhook-pre-commit.staged.XXXXXX")
+formatted_file=$(mktemp "${TMPDIR:-/tmp}/safetyhook-pre-commit.formatted.XXXXXX")
 
 cleanup() {
     rm -f "$files" "$staged_file" "$formatted_file"

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -10,9 +10,8 @@ fi
 clang_format_version=$(clang-format --version | sed -n 's/.*version \([0-9][0-9]*\).*/\1/p')
 
 if [ "$clang_format_version" != "22" ]; then
-    echo "error: clang-format 22 is required for this repository." >&2
+    echo "warning: clang-format 22 is used by CI for this repository." >&2
     echo "found: $(clang-format --version)" >&2
-    exit 1
 fi
 
 files=$(mktemp)

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,61 @@
+#!/bin/sh
+
+set -eu
+
+if ! command -v clang-format >/dev/null 2>&1; then
+    echo "error: clang-format is required for this repository." >&2
+    exit 1
+fi
+
+files=$(mktemp)
+staged_file=$(mktemp)
+formatted_file=$(mktemp)
+
+cleanup() {
+    rm -f "$files" "$staged_file" "$formatted_file"
+}
+
+trap cleanup EXIT HUP INT TERM
+
+git diff --cached --name-only --diff-filter=ACMR -- \
+    '*.c' '*.cc' '*.cpp' '*.cxx' \
+    '*.h' '*.hh' '*.hpp' '*.hxx' \
+    '*.cppm' >"$files"
+
+if [ ! -s "$files" ]; then
+    exit 0
+fi
+
+status=0
+
+while IFS= read -r file; do
+    if [ ! -f "$file" ]; then
+        continue
+    fi
+
+    git show ":$file" >"$staged_file"
+    clang-format -style=file --assume-filename="$file" <"$staged_file" >"$formatted_file"
+
+    if ! cmp -s "$staged_file" "$formatted_file"; then
+        echo "error: $file is not clang-formatted." >&2
+        status=1
+    fi
+done <"$files"
+
+if [ "$status" -ne 0 ]; then
+    cat >&2 <<'EOF'
+
+Format the files above, then stage them again.
+
+bash:
+  find src include test example module -type f \( -name '*.c' -o -name '*.cc' -o -name '*.cpp' -o -name '*.cxx' -o -name '*.h' -o -name '*.hh' -o -name '*.hpp' -o -name '*.hxx' -o -name '*.cppm' \) -exec clang-format -i -style=file {} +
+
+pwsh:
+  Get-ChildItem src,include,test,example,module -Recurse -Include *.c,*.cc,*.cpp,*.cxx,*.h,*.hh,*.hpp,*.hxx,*.cppm | ForEach-Object { clang-format -i -style=file $_.FullName }
+
+cmd:
+  for %d in (src include test example module) do @for /r %d %f in (*.c *.cc *.cpp *.cxx *.h *.hh *.hpp *.hxx *.cppm) do @clang-format -i -style=file "%f"
+EOF
+fi
+
+exit "$status"

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -7,6 +7,14 @@ if ! command -v clang-format >/dev/null 2>&1; then
     exit 1
 fi
 
+clang_format_version=$(clang-format --version | sed -n 's/.*version \([0-9][0-9]*\).*/\1/p')
+
+if [ "$clang_format_version" != "22" ]; then
+    echo "error: clang-format 22 is required for this repository." >&2
+    echo "found: $(clang-format --version)" >&2
+    exit 1
+fi
+
 files=$(mktemp)
 staged_file=$(mktemp)
 formatted_file=$(mktemp)
@@ -45,7 +53,7 @@ done <"$files"
 if [ "$status" -ne 0 ]; then
     cat >&2 <<'EOF'
 
-Format the files above, then stage them again.
+Format the files above with clang-format 22, then stage them again.
 
 bash:
   find src include test example module -type f \( -name '*.c' -o -name '*.cc' -o -name '*.cpp' -o -name '*.cxx' -o -name '*.h' -o -name '*.hh' -o -name '*.hpp' -o -name '*.hxx' -o -name '*.cppm' \) -exec clang-format -i -style=file {} +

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,9 +7,27 @@ on:
       - v*
 
 jobs:
+  formatting:
+    name: clang-format
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6.0.3
+
+      - name: Install clang-format
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang-format
+
+      - name: Check formatting
+        run: |
+          mapfile -t files < <(find src include test example module -type f \( -name '*.c' -o -name '*.cc' -o -name '*.cpp' -o -name '*.cxx' -o -name '*.h' -o -name '*.hh' -o -name '*.hpp' -o -name '*.hxx' -o -name '*.cppm' \))
+          clang-format --dry-run --Werror -style=file "${files[@]}"
+
   build:
     name: ${{matrix.os}} ${{matrix.arch}} ${{matrix.compiler}} ${{matrix.build_type}}
     runs-on: ${{matrix.os}}
+    needs: formatting
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,15 +14,17 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6.0.3
 
-      - name: Install clang-format
+      - name: Install clang-format 22
         run: |
-          sudo apt-get update
-          sudo apt-get install -y clang-format
+          curl -fsSL https://apt.llvm.org/llvm.sh -o llvm.sh
+          chmod +x llvm.sh
+          sudo ./llvm.sh 22
+          sudo apt-get install -y clang-format-22
 
       - name: Check formatting
         run: |
           mapfile -t files < <(find src include test example module -type f \( -name '*.c' -o -name '*.cc' -o -name '*.cpp' -o -name '*.cxx' -o -name '*.h' -o -name '*.hh' -o -name '*.hpp' -o -name '*.hxx' -o -name '*.cppm' \))
-          clang-format --dry-run --Werror -style=file "${files[@]}"
+          clang-format-22 --dry-run --Werror -style=file "${files[@]}"
 
   build:
     name: ${{matrix.os}} ${{matrix.arch}} ${{matrix.compiler}} ${{matrix.build_type}}

--- a/format.ps1
+++ b/format.ps1
@@ -1,5 +1,0 @@
-Get-ChildItem -Path .\src, .\include, .\test, .\example -Include *.hpp, *.cpp -Recurse |
-ForEach-Object {
-    Write-Output $_.FullName
-    &clang-format -i -style=file $_.FullName
-}

--- a/include/safetyhook.hpp
+++ b/include/safetyhook.hpp
@@ -1,9 +1,9 @@
 #pragma once
 
-#include "safetyhook/os.hpp"
 #include "safetyhook/easy.hpp"
 #include "safetyhook/inline_hook.hpp"
 #include "safetyhook/mid_hook.hpp"
+#include "safetyhook/os.hpp"
 #include "safetyhook/vmt_hook.hpp"
 
 using SafetyHookContext = safetyhook::Context;

--- a/src/allocator.cpp
+++ b/src/allocator.cpp
@@ -225,7 +225,7 @@ std::expected<uint8_t*, Allocator::Error> Allocator::allocate_nearby_memory(
 
     // Search backwards from the desired_address.
     for (auto p = desired_address; p > search_start && in_range(p, desired_addresses, max_distance);
-         p = align_down(mbi.address - 1, si.allocation_granularity)) {
+        p = align_down(mbi.address - 1, si.allocation_granularity)) {
         auto result = vm_query(p);
 
         if (!result) {

--- a/src/inline_hook.cpp
+++ b/src/inline_hook.cpp
@@ -284,9 +284,7 @@ std::expected<void, InlineHook::Error> InlineHook::e9_hook(const std::shared_ptr
 
         if (
 #if SAFETYHOOK_ARCH_X86_32
-            auto thunk_reg = x86_get_pc_thunk_register(ip, ix);
-            thunk_reg
-        ) {
+            auto thunk_reg = x86_get_pc_thunk_register(ip, ix); thunk_reg) {
             emit_mov_r32_imm32(tramp_ip, *thunk_reg, ip + ix.length);
             tramp_ip += ix.length;
         } else if (

--- a/src/inline_hook.cpp
+++ b/src/inline_hook.cpp
@@ -281,19 +281,16 @@ std::expected<void, InlineHook::Error> InlineHook::e9_hook(const std::shared_ptr
         }
 
         const auto is_relative = (ix.attributes & ZYDIS_ATTRIB_IS_RELATIVE) != 0;
-        auto handled_instruction = false;
 
 #if SAFETYHOOK_ARCH_X86_32
         if (auto thunk_reg = x86_get_pc_thunk_register(ip, ix); thunk_reg) {
             emit_mov_r32_imm32(tramp_ip, *thunk_reg, ip + ix.length);
             tramp_ip += ix.length;
-            handled_instruction = true;
+            continue;
         }
 #endif
 
-        if (handled_instruction) {
-            continue;
-        } else if (is_relative && ix.raw.disp.size == 32) {
+        if (is_relative && ix.raw.disp.size == 32) {
             std::copy_n(ip, ix.length, tramp_ip);
             const auto target_address = ip + ix.length + ix.raw.disp.value;
             const auto new_disp = target_address - (tramp_ip + ix.length);

--- a/src/inline_hook.cpp
+++ b/src/inline_hook.cpp
@@ -281,15 +281,19 @@ std::expected<void, InlineHook::Error> InlineHook::e9_hook(const std::shared_ptr
         }
 
         const auto is_relative = (ix.attributes & ZYDIS_ATTRIB_IS_RELATIVE) != 0;
+        auto handled_instruction = false;
 
-        if (
 #if SAFETYHOOK_ARCH_X86_32
-            auto thunk_reg = x86_get_pc_thunk_register(ip, ix); thunk_reg) {
+        if (auto thunk_reg = x86_get_pc_thunk_register(ip, ix); thunk_reg) {
             emit_mov_r32_imm32(tramp_ip, *thunk_reg, ip + ix.length);
             tramp_ip += ix.length;
-        } else if (
+            handled_instruction = true;
+        }
 #endif
-            is_relative && ix.raw.disp.size == 32) {
+
+        if (handled_instruction) {
+            continue;
+        } else if (is_relative && ix.raw.disp.size == 32) {
             std::copy_n(ip, ix.length, tramp_ip);
             const auto target_address = ip + ix.length + ix.raw.disp.value;
             const auto new_disp = target_address - (tramp_ip + ix.length);

--- a/src/os.linux.cpp
+++ b/src/os.linux.cpp
@@ -84,7 +84,7 @@ std::expected<uint32_t, OsError> vm_protect(uint8_t* address, size_t size, uint3
     auto* addr = align_down(address, static_cast<size_t>(sysconf(_SC_PAGESIZE)));
 
     size = size + static_cast<size_t>(address - addr);
-    
+
     if (mprotect(addr, size, static_cast<int>(protect)) == -1) {
         return std::unexpected{OsError::FAILED_TO_PROTECT};
     }


### PR DESCRIPTION
## Summary

- Add a portable Git pre-commit hook that checks staged C and C++ files with `clang-format`.
- Warn locally when the `clang-format` major version is not 22, while leaving CI as the authoritative pinned check.
- Add a CI formatting gate that installs `clang-format-22` and runs before the build matrix.
- Remove the PowerShell-only formatting script.
- Apply clang-format fixes to existing files that failed the formatter dry-run check.
- Address review feedback by using portable `mktemp` templates and simplifying the preprocessor-wrapped thunk handling.

## Validation

- `clang-format --dry-run --Werror -style=file` with clang-format 22 across `src`, `include`, `test`, `example`, and `module`.
- Pre-commit hook run locally with clang-format 22 on `PATH`.
- GitHub Actions passed on PR #128 after the review feedback updates.