### PR TITLE
Make linked library of module target private

### DIFF
--- a/module/CMakeLists.txt
+++ b/module/CMakeLists.txt
@@ -1,7 +1,7 @@
 add_library(safetyhook-module STATIC)
 add_library(safetyhook::safetyhook-module ALIAS safetyhook-module)
 
-target_link_libraries(safetyhook-module PUBLIC safetyhook::safetyhook)
+target_link_libraries(safetyhook-module PRIVATE safetyhook::safetyhook)
 target_sources(safetyhook-module
     PUBLIC
         FILE_SET CXX_MODULES


### PR DESCRIPTION
This hides safetyhook headers from consumers of the module target. Those who want to use both modules *and* headers (though I can't imagine why anyone would want to do this) can do so by explicitly linking both targets.